### PR TITLE
feat(tl-c8n): fix Docker paths, add Dockerfile.dev, normalize env var names

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,19 +10,17 @@ services:
 
   frontend:
     build:
-      context: ./services/frontend
+      context: ./frontend
       dockerfile: Dockerfile.dev
-      # NEXT_PUBLIC_* must be build args even in dev mode
-      args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
-        NEXT_PUBLIC_TUTORING_URL: ${NEXT_PUBLIC_TUTORING_URL:-http://localhost:8000}
     volumes:
-      - ./services/frontend:/app
+      - ./frontend:/app
       - /app/node_modules      # preserve node_modules from image
       - /app/.next             # preserve Next.js build cache from image
     environment:
       NODE_ENV: development
       WATCHPACK_POLLING: "true"   # needed for some Docker/macOS setups
+      USER_SERVICE_URL: http://user-service:8080
+      TUTORING_SERVICE_URL: http://tutoring-service:8000
 
   user-service:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,13 +149,8 @@ services:
 
   frontend:
     build:
-      context: ./services/frontend
+      context: ./frontend
       dockerfile: Dockerfile
-      # NEXT_PUBLIC_* vars must be passed as build args — they are baked into
-      # the JS bundle at compile time and cannot be overridden at runtime.
-      args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
-        NEXT_PUBLIC_TUTORING_URL: ${NEXT_PUBLIC_TUTORING_URL:-http://localhost:8000}
     restart: unless-stopped
     depends_on:
       user-service:
@@ -165,8 +160,8 @@ services:
     environment:
       NODE_ENV: production
       # Server-side (SSR) URLs use Docker internal hostnames — not exposed to browser
-      API_URL: http://user-service:8080
-      TUTORING_URL: http://tutoring-service:8000
+      USER_SERVICE_URL: http://user-service:8080
+      TUTORING_SERVICE_URL: http://tutoring-service:8000
     ports:
       - "127.0.0.1:3000:3000"
     healthcheck:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -30,4 +30,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://localhost:3000/api/health || exit 1
+
 CMD ["node", "server.js"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,13 @@
+# Development Dockerfile — Next.js dev server with hot reload
+# Used by: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+# Source is bind-mounted at runtime — no COPY of app code needed.
+FROM node:22-alpine
+WORKDIR /app
+RUN apk add --no-cache libc6-compat
+COPY package.json package-lock.json* ./
+RUN npm ci
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+ENV NEXT_TELEMETRY_DISABLED=1
+CMD ["npm", "run", "dev"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next'
 
 const USER_SERVICE_URL = process.env.USER_SERVICE_URL || 'http://user-service:8080'
-const TUTORING_SERVICE_URL = process.env.TUTORING_SERVICE_URL || 'http://tutoring-service:8080'
+const TUTORING_SERVICE_URL = process.env.TUTORING_SERVICE_URL || 'http://tutoring-service:8000'
 
 const config: NextConfig = {
   output: 'standalone',


### PR DESCRIPTION
## What

- Fix build context path: `services/frontend` → `frontend` (correct repo layout)
- Fix tutoring-service port in next.config.ts: 8080 → 8000 (FastAPI default)
- Rename `API_URL`/`TUTORING_URL` → `USER_SERVICE_URL`/`TUTORING_SERVICE_URL` to match next.config.ts rewrites
- Remove incorrect `NEXT_PUBLIC_*` build args (these are SSR server-side URLs, not browser-baked constants)
- Add `frontend/Dockerfile.dev`: node:22-alpine dev server with HMR for `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
- Add HEALTHCHECK to prod Dockerfile (wget → `/api/health`, 30s interval)

## Why

Bead ID: tl-c8n — Frontend Service Docker/compose setup.
Build was broken (wrong context path). Env var naming was inconsistent with next.config.ts. Dev workflow needed a proper hot-reload Dockerfile.

## How to test

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml up frontend
# → Next.js dev server on :3000 with hot reload

docker compose up frontend
# → Production standalone build, healthcheck active
```

## Checklist
- [x] Tests pass
- [x] Lint clean
- [x] No secrets committed

> Rescued from stopped nitro session — work committed by petra (PM recovery)

Closes tl-c8n