### PR TITLE
fix(frontend): remove upgrade-insecure-requests from CSP

### DIFF
--- a/frontend/lib/csp.test.ts
+++ b/frontend/lib/csp.test.ts
@@ -10,7 +10,7 @@ describe('buildCsp', () => {
     const csp = buildCsp()
     expect(csp).toContain("default-src 'self'")
     expect(csp).toContain("frame-ancestors 'none'")
-    expect(csp).toContain('upgrade-insecure-requests')
+    expect(csp).not.toContain('upgrade-insecure-requests')
     expect(csp).toContain("form-action 'self'")
   })
 

--- a/frontend/lib/csp.ts
+++ b/frontend/lib/csp.ts
@@ -38,10 +38,9 @@ export function buildCsp(nonce?: string): string {
     "form-action 'self'",
   ]
 
-  // Only upgrade to HTTPS in production — local dev runs over plain HTTP
-  if (process.env.NODE_ENV === 'production' && process.env.DISABLE_HSTS !== 'true') {
-    directives.push('upgrade-insecure-requests')
-  }
+  // upgrade-insecure-requests is handled by the reverse proxy (nginx/caddy)
+  // in production. Next.js standalone bakes CSP at build time, so we cannot
+  // toggle it with runtime env vars.
 
   return directives.join('; ')
 }

--- a/frontend/next.config.test.ts
+++ b/frontend/next.config.test.ts
@@ -26,7 +26,7 @@ describe('next.config security headers', () => {
     expect(csp).toBeDefined()
     expect(csp!.value).toContain("default-src 'self'")
     expect(csp!.value).toContain("frame-ancestors 'none'")
-    expect(csp!.value).toContain('upgrade-insecure-requests')
+    expect(csp!.value).not.toContain('upgrade-insecure-requests')
     expect(csp!.value).toContain("form-action 'self'")
   })
 
@@ -40,10 +40,9 @@ describe('next.config security headers', () => {
     expect(h?.value).toBe('nosniff')
   })
 
-  it('sets HSTS with long max-age and includeSubDomains', () => {
+  it('does not set HSTS — handled by reverse proxy in production', () => {
     const h = headers.find((hdr) => hdr.key === 'Strict-Transport-Security')
-    expect(h?.value).toContain('max-age=63072000')
-    expect(h?.value).toContain('includeSubDomains')
+    expect(h).toBeUndefined()
   })
 
   it('sets Referrer-Policy', () => {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -18,19 +18,16 @@ const TUTORING_SERVICE_URL = process.env.TUTORING_SERVICE_URL || 'http://tutorin
  * - media-src blob:: TTS audio via Web Audio API
  * - worker-src blob:: Three.js OffscreenCanvas workers
  */
-function getSecurityHeaders() {
-  const headers = [
-    { key: 'Content-Security-Policy', value: buildCsp() },
-    { key: 'X-Frame-Options', value: 'DENY' },
-    { key: 'X-Content-Type-Options', value: 'nosniff' },
-    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-    { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
-  ]
-  if (process.env.DISABLE_HSTS !== 'true') {
-    headers.push({ key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' })
-  }
-  return headers
-}
+// HSTS and upgrade-insecure-requests are handled by the reverse proxy
+// (nginx/caddy) in production. Next.js standalone bakes headers() at
+// build time, so runtime env vars cannot toggle them.
+const SECURITY_HEADERS = [
+  { key: 'Content-Security-Policy', value: buildCsp() },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+]
 
 const config: NextConfig = {
   output: 'standalone',
@@ -40,7 +37,7 @@ const config: NextConfig = {
       {
         // Apply security headers to every route.
         source: '/(.*)',
-        headers: getSecurityHeaders(),
+        headers: SECURITY_HEADERS,
       },
     ]
   },


### PR DESCRIPTION
Also baked at build time in standalone mode. Both HSTS and upgrade-insecure now delegated to reverse proxy. Tests updated.