### PR TITLE
feat(tl-d1u): onboarding polish — loading state + error test coverage

### DIFF
--- a/frontend/components/onboarding/OnboardingWizard.tsx
+++ b/frontend/components/onboarding/OnboardingWizard.tsx
@@ -52,6 +52,7 @@ export default function OnboardingWizard({
   const [currentName, setCurrentName] = useState(displayName)
   const [currentAvatar, setCurrentAvatar] = useState(avatarEmoji || '🎓')
   const [completionError, setCompletionError] = useState<string | null>(null)
+  const [finishing, setFinishing] = useState(false)
 
   const step = STEPS[stepIndex]
   const totalSteps = STEPS.length
@@ -89,6 +90,7 @@ export default function OnboardingWizard({
    */
   async function finishOnboarding() {
     setCompletionError(null)
+    setFinishing(true)
     try {
       const res = await fetch('/api/user/onboarding', { method: 'PATCH' })
       if (!res.ok && res.status !== 204) {
@@ -140,6 +142,7 @@ export default function OnboardingWizard({
           <ReadyStep
             avatarEmoji={currentAvatar}
             displayName={currentName}
+            finishing={finishing}
             onDone={finishOnboarding}
           />
         )}

--- a/frontend/components/onboarding/ReadyStep.test.tsx
+++ b/frontend/components/onboarding/ReadyStep.test.tsx
@@ -18,7 +18,6 @@ describe('ReadyStep', () => {
 
   it('shows the avatar emoji', () => {
     render(<ReadyStep avatarEmoji="🦊" displayName="FoxUser" onDone={() => {}} />)
-    // The emoji appears in the avatar display
     expect(screen.getAllByText('🦊').length).toBeGreaterThan(0)
   })
 
@@ -33,5 +32,17 @@ describe('ReadyStep', () => {
     render(<ReadyStep avatarEmoji="🎓" displayName="Bob" onDone={onDone} />)
     fireEvent.click(screen.getByRole('button', { name: /start learning/i }))
     expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Launching..." and disables button when finishing', () => {
+    render(<ReadyStep avatarEmoji="🎓" displayName="Alice" finishing onDone={() => {}} />)
+    const btn = screen.getByRole('button', { name: /launching/i })
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveTextContent('Launching...')
+  })
+
+  it('shows normal button text when not finishing', () => {
+    render(<ReadyStep avatarEmoji="🎓" displayName="Alice" finishing={false} onDone={() => {}} />)
+    expect(screen.getByRole('button', { name: /start learning/i })).toBeEnabled()
   })
 })

--- a/frontend/components/onboarding/ReadyStep.tsx
+++ b/frontend/components/onboarding/ReadyStep.tsx
@@ -12,6 +12,8 @@ interface ReadyStepProps {
   avatarEmoji: string
   /** The user's chosen display name, shown in the celebration heading. */
   displayName: string
+  /** Whether the completion API call is in progress. */
+  finishing?: boolean
   /** Called when the user clicks "Start learning". */
   onDone: () => void
 }
@@ -21,9 +23,10 @@ interface ReadyStepProps {
  *
  * @param props.avatarEmoji - User's chosen avatar.
  * @param props.displayName - User's display name.
+ * @param props.finishing - Whether the completion call is in flight.
  * @param props.onDone - Navigate to the main tutoring interface.
  */
-export default function ReadyStep({ avatarEmoji, displayName, onDone }: ReadyStepProps) {
+export default function ReadyStep({ avatarEmoji, displayName, finishing, onDone }: ReadyStepProps) {
   return (
     <div className="flex flex-col items-center text-center gap-6">
       <div className="relative">
@@ -49,8 +52,12 @@ export default function ReadyStep({ avatarEmoji, displayName, onDone }: ReadySte
         <p>✓ 14-day free trial active</p>
       </div>
 
-      <button onClick={onDone} className="neon-btn-primary w-full max-w-xs text-base">
-        Start learning ⚡
+      <button
+        onClick={onDone}
+        disabled={finishing}
+        className="neon-btn-primary w-full max-w-xs text-base"
+      >
+        {finishing ? 'Launching...' : 'Start learning ⚡'}
       </button>
     </div>
   )

--- a/frontend/components/onboarding/onboardingWizard.test.tsx
+++ b/frontend/components/onboarding/onboardingWizard.test.tsx
@@ -9,10 +9,11 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-// next/navigation is mocked by jest moduleNameMapper in jest.config.ts via
-// the __mocks__ directory convention.  We provide a minimal inline mock here.
+const mockPush = jest.fn()
+const mockRefresh = jest.fn()
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }))
 
 global.fetch = jest.fn()
@@ -33,9 +34,37 @@ function mockFetchOk() {
   })
 }
 
+function mockFetchFail(status = 500) {
+  ;(global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({ error: 'server error' }),
+  })
+}
+
+function mockFetchNetworkError() {
+  ;(global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'))
+}
+
+/** Advance wizard to a given step index by clicking through. */
+async function advanceTo(stepIndex: number) {
+  if (stepIndex >= 1) {
+    fireEvent.click(screen.getByRole('button', { name: /let's go/i }))
+  }
+  if (stepIndex >= 2) {
+    fireEvent.click(screen.getByRole('button', { name: /looks good/i }))
+    await waitFor(() => screen.getByText(/upload your study materials/i))
+  }
+  if (stepIndex >= 3) {
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }))
+  }
+}
+
 describe('OnboardingWizard', () => {
   beforeEach(() => {
     ;(global.fetch as jest.Mock).mockReset()
+    mockPush.mockReset()
+    mockRefresh.mockReset()
   })
 
   it('renders the welcome step first', () => {
@@ -54,7 +83,6 @@ describe('OnboardingWizard', () => {
     render(<OnboardingWizard {...defaultProps} />)
 
     fireEvent.click(screen.getByRole('button', { name: /let's go/i }))
-    // Submit character step with defaults
     fireEvent.click(screen.getByRole('button', { name: /looks good/i }))
 
     await waitFor(() => {
@@ -79,7 +107,6 @@ describe('OnboardingWizard', () => {
 
   it('renders progress dots equal to number of steps', () => {
     render(<OnboardingWizard {...defaultProps} />)
-    // 4 steps → 4 progress dots (divs inside progressbar)
     const bar = screen.getByRole('progressbar')
     const dots = bar.querySelectorAll('div')
     expect(dots).toHaveLength(4)
@@ -98,5 +125,111 @@ describe('OnboardingWizard', () => {
         expect.objectContaining({ method: 'PATCH' }),
       )
     })
+  })
+
+  // --- Error state tests ---
+
+  it('stays on character step when save API returns an error', async () => {
+    mockFetchFail()
+    render(<OnboardingWizard {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /let's go/i }))
+    fireEvent.click(screen.getByRole('button', { name: /looks good/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to save/i)).toBeInTheDocument()
+    })
+    // Still on character step
+    expect(screen.getByText(/create your character/i)).toBeInTheDocument()
+  })
+
+  it('shows completion error when onboarding PATCH fails', async () => {
+    // First call (character save) succeeds, second call (onboarding complete) fails
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 204, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+
+    render(<OnboardingWizard {...defaultProps} />)
+    await advanceTo(3)
+
+    fireEvent.click(screen.getByRole('button', { name: /start learning/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/could not save progress/i)).toBeInTheDocument()
+    })
+    // Still navigates to home despite error
+    expect(mockPush).toHaveBeenCalledWith('/')
+  })
+
+  it('shows network error when onboarding PATCH throws', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 204, json: async () => ({}) })
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    render(<OnboardingWizard {...defaultProps} />)
+    await advanceTo(3)
+
+    fireEvent.click(screen.getByRole('button', { name: /start learning/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/network error/i)).toBeInTheDocument()
+    })
+    expect(mockPush).toHaveBeenCalledWith('/')
+  })
+
+  it('navigates to home and refreshes on successful completion', async () => {
+    mockFetchOk()
+    render(<OnboardingWizard {...defaultProps} />)
+    await advanceTo(3)
+
+    fireEvent.click(screen.getByRole('button', { name: /start learning/i }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/')
+      expect(mockRefresh).toHaveBeenCalled()
+    })
+  })
+
+  // --- Progress dot state tests ---
+
+  it('marks completed steps with green styling in progress dots', async () => {
+    mockFetchOk()
+    render(<OnboardingWizard {...defaultProps} />)
+
+    const bar = screen.getByRole('progressbar')
+    const dots = bar.querySelectorAll('div')
+
+    // Initially first dot is current (blue), rest are pending
+    expect(dots[0].className).toContain('bg-neon-blue')
+    expect(dots[1].className).toContain('bg-border-mid')
+
+    // Advance to step 2
+    fireEvent.click(screen.getByRole('button', { name: /let's go/i }))
+    const updatedDots = bar.querySelectorAll('div')
+    expect(updatedDots[0].className).toContain('bg-neon-green')
+    expect(updatedDots[1].className).toContain('bg-neon-blue')
+  })
+
+  it('shows finishing state on ready step button during completion', async () => {
+    let resolveOnboarding!: (value: Response) => void
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, status: 204, json: async () => ({}) })
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((r) => {
+            resolveOnboarding = r
+          }),
+      )
+
+    render(<OnboardingWizard {...defaultProps} />)
+    await advanceTo(3)
+
+    fireEvent.click(screen.getByRole('button', { name: /start learning/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /launching/i })).toBeDisabled()
+    })
+
+    resolveOnboarding({ ok: true, status: 204, json: async () => ({}) } as Response)
   })
 })


### PR DESCRIPTION
## What
Polish pass on the onboarding wizard (originally landed in PR #143).

## Why
Bead ID: tl-d1u — the first-run wizard needed loading states for the completion flow and comprehensive test coverage for error paths.

## Changes
- **ReadyStep**: new `finishing` prop — disables button and shows "Launching..." during the completion API call
- **OnboardingWizard**: tracks `finishing` state, passes to ReadyStep
- **Tests (24 → 32)**:
  - Character save API failure — stays on step, shows error
  - Completion PATCH failure — shows error, still navigates home
  - Completion network error — shows network message, still navigates
  - Successful completion — verifies `router.push('/')` + `router.refresh()`
  - Progress dot CSS transitions (green/blue/gray)
  - ReadyStep finishing button state (disabled + text change)

## How to test
```bash
cd frontend && npx jest "onboarding"
# 32 tests, 5 suites — all pass
```

## Checklist
- [x] Tests written (TDD) — 8 new tests across 2 test files
- [x] Coverage ≥80% on new code
- [x] Docstrings on all new functions/classes
- [x] Lint clean
- [x] No secrets committed
- [x] Self-review: read own diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)