### PR TITLE
feat(tl-8gw): add strict-dynamic to CSP nonce policy

### DIFF
--- a/frontend/lib/csp.test.ts
+++ b/frontend/lib/csp.test.ts
@@ -14,21 +14,24 @@ describe('buildCsp', () => {
     expect(csp).toContain("form-action 'self'")
   })
 
-  it('without nonce: script-src is self only, no unsafe-inline', () => {
+  it('without nonce: script-src is self only, no unsafe-inline, no strict-dynamic', () => {
     const csp = buildCsp()
     expect(csp).toContain("script-src 'self'")
     const scriptSrc = csp.match(/script-src([^;]+)/)?.[1] ?? ''
     expect(scriptSrc).not.toContain('unsafe-inline')
     expect(scriptSrc).not.toContain('nonce-')
+    // strict-dynamic without a nonce would block all scripts — must be absent
+    expect(scriptSrc).not.toContain('strict-dynamic')
   })
 
-  it('with nonce: script-src contains the nonce directive', () => {
+  it('with nonce: script-src contains nonce and strict-dynamic', () => {
     const nonce = 'abc123=='
     const csp = buildCsp(nonce)
     expect(csp).toContain(`'nonce-${nonce}'`)
-    expect(csp).toContain("script-src 'self' 'nonce-abc123=='")
+    expect(csp).toContain("script-src 'self' 'nonce-abc123==' 'strict-dynamic'")
     const scriptSrc = csp.match(/script-src([^;]+)/)?.[1] ?? ''
     expect(scriptSrc).not.toContain('unsafe-inline')
+    expect(scriptSrc).toContain('strict-dynamic')
   })
 
   it('with nonce: nonce value is embedded verbatim', () => {

--- a/frontend/lib/csp.ts
+++ b/frontend/lib/csp.ts
@@ -10,8 +10,10 @@
  * Build a Content-Security-Policy header value.
  *
  * When a `nonce` is supplied the `script-src` directive uses
- * `'nonce-<value>'` in place of `'unsafe-inline'`, satisfying
- * Level-2 CSP without weakening XSS protection.
+ * `'nonce-<value>' 'strict-dynamic'` in place of `'unsafe-inline'`.
+ * `'strict-dynamic'` allows Next.js to load code-split chunks that are
+ * dynamically injected by nonce-trusted bootstrap scripts, satisfying
+ * CSP Level 3 without `'unsafe-inline'` or a per-chunk URL allowlist.
  *
  * Without a nonce (e.g. static API routes that bypass middleware)
  * `script-src` falls back to `'self'` only — no inline scripts are
@@ -23,7 +25,9 @@
  *   HTTP `Content-Security-Policy` header.
  */
 export function buildCsp(nonce?: string): string {
-  const scriptSrc = nonce ? `'self' 'nonce-${nonce}'` : "'self'"
+  const scriptSrc = nonce
+    ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
+    : "'self'"
 
   const directives = [
     "default-src 'self'",

--- a/frontend/lib/csp.ts
+++ b/frontend/lib/csp.ts
@@ -25,9 +25,7 @@
  *   HTTP `Content-Security-Policy` header.
  */
 export function buildCsp(nonce?: string): string {
-  const scriptSrc = nonce
-    ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
-    : "'self'"
+  const scriptSrc = nonce ? `'self' 'nonce-${nonce}' 'strict-dynamic'` : "'self'"
 
   const directives = [
     "default-src 'self'",

--- a/frontend/middleware.test.ts
+++ b/frontend/middleware.test.ts
@@ -71,7 +71,7 @@ describe('middleware CSP nonce injection', () => {
     const req = makeRequest('/', fakeJwt({ sub_status: 'active' }))
     const res = middleware(req)
     const csp = res.headers.get('Content-Security-Policy') ?? ''
-    expect(csp).toMatch(/script-src 'self' 'nonce-[A-Za-z0-9+/=]+'/)
+    expect(csp).toMatch(/script-src 'self' 'nonce-[A-Za-z0-9+/=]+' 'strict-dynamic'/)
   })
 
   it('script-src in CSP does not contain unsafe-inline', () => {


### PR DESCRIPTION
## Summary

- Adds `'strict-dynamic'` to `script-src` in `buildCsp()` when a per-request nonce is present
- Without `'strict-dynamic'`, Next.js code-split chunks injected at runtime by nonce-trusted scripts are blocked by CSP — this was a gap in the tl-ixk implementation
- Static fallback (API routes/assets bypassing middleware) keeps `script-src 'self'` only — `'strict-dynamic'` without a nonce would block all scripts on those routes
- Updates 3 tests: adds `strict-dynamic` assertion in `csp.test.ts`, updates regex in `middleware.test.ts`

## Test plan

- [x] `lib/csp.test.ts` — 7 tests pass, including new strict-dynamic assertion
- [x] `middleware.test.ts` — 18 tests pass with updated script-src regex
- [x] `next.config.test.ts` — 8 tests pass (static fallback unchanged)
- [x] Full suite: 709 tests across 78 suites, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)