### PR TITLE
feat(tl-c47): Playwright E2E smoke tests — all 7 user journeys

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.auth/
+test-results/
+playwright-report/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "teacherslounge-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "teacherslounge-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "@types/node": "^22.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "teacherslounge-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright E2E smoke tests for TeachersLounge",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "install:browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright configuration for TeachersLounge E2E smoke tests.
+ *
+ * Targets a running docker-compose stack at localhost:3000.
+ * Run `docker compose --env-file .env.local up --build` first.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  timeout: 60_000,
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    // Treat localhost as secure so httpOnly+secure cookies are sent over HTTP
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    trace: 'retain-on-failure',
+  },
+
+  projects: [
+    // Global setup — registers a test user and saves auth state
+    {
+      name: 'setup',
+      testMatch: '**/global-setup.ts',
+    },
+    // Smoke tests — depend on auth state from setup
+    {
+      name: 'smoke',
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: '.auth/state.json',
+      },
+    },
+  ],
+})

--- a/e2e/tests/global-setup.ts
+++ b/e2e/tests/global-setup.ts
@@ -1,0 +1,48 @@
+import { test as setup, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const AUTH_FILE = path.join(__dirname, '../.auth/state.json')
+
+/**
+ * Global setup — runs once before all smoke tests.
+ *
+ * Registers a fresh test user then saves the browser storage state
+ * (cookies including tl_token) so subsequent tests start authenticated.
+ * A timestamp-based email ensures uniqueness across test runs.
+ */
+setup('register test user', async ({ page }) => {
+  const ts = Date.now()
+  const email = `e2e+${ts}@test.local`
+  const password = 'Smoke_test_pw1!'
+  const displayName = `SmokeUser${ts}`
+
+  // Store credentials in env so individual tests can login if needed
+  process.env.E2E_EMAIL = email
+  process.env.E2E_PASSWORD = password
+  process.env.E2E_DISPLAY_NAME = displayName
+
+  // Write credentials to a temp file for cross-process access
+  const credDir = path.join(__dirname, '../.auth')
+  fs.mkdirSync(credDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(credDir, 'credentials.json'),
+    JSON.stringify({ email, password, displayName }),
+  )
+
+  await page.goto('/register')
+  await expect(page).toHaveURL('/register')
+
+  await page.fill('#display-name', displayName)
+  await page.fill('#email', email)
+  await page.fill('#password', password)
+  await page.fill('#confirm', password)
+  await page.click('button[type="submit"]')
+
+  // After register the token cookie is set; middleware redirects away from
+  // /subscribe (a public path) to / for authenticated users.
+  await expect(page).toHaveURL('/', { timeout: 15_000 })
+
+  // Persist auth state for downstream tests
+  await page.context().storageState({ path: AUTH_FILE })
+})

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,285 @@
+import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Load credentials written by global-setup. */
+function loadCredentials(): { email: string; password: string; displayName: string } {
+  const credFile = path.join(__dirname, '../.auth/credentials.json')
+  return JSON.parse(fs.readFileSync(credFile, 'utf-8'))
+}
+
+// ── 1. Register + Login ───────────────────────────────────────────────────────
+
+test.describe('Register + Login', () => {
+  /**
+   * The global-setup already registers a user; here we verify login with those
+   * same credentials works end-to-end.  We use a fresh context (no storageState)
+   * so we're not relying on existing cookies.
+   */
+  test('login with registered credentials lands on home', async ({ browser }) => {
+    const { email, password } = loadCredentials()
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto('/login')
+    await expect(page.locator('h1')).toContainText('Welcome back')
+
+    await page.fill('#email', email)
+    await page.fill('#password', password)
+    await page.click('button[type="submit"]')
+
+    await expect(page).toHaveURL('/', { timeout: 15_000 })
+    await context.close()
+  })
+
+  test('registration form rejects mismatched passwords', async ({ browser }) => {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto('/register')
+    await page.fill('#display-name', 'TestUser')
+    await page.fill('#email', `mismatch+${Date.now()}@test.local`)
+    await page.fill('#password', 'Password1!')
+    await page.fill('#confirm', 'DifferentPass1!')
+    await page.click('button[type="submit"]')
+
+    await expect(page.locator('text=Passwords do not match')).toBeVisible()
+    await context.close()
+  })
+})
+
+// ── 2. Onboarding Wizard ──────────────────────────────────────────────────────
+
+test.describe('Onboarding wizard', () => {
+  /**
+   * Navigates to /onboard and walks through all four steps:
+   * welcome → character → upload-guide → ready → /
+   *
+   * Uses the auth storageState provided via playwright.config.ts projects.
+   */
+  test('completes all wizard steps and lands on home', async ({ page }) => {
+    await page.goto('/onboard')
+
+    // Step 1 — Welcome: "Let's go ⚡" button
+    const letsGo = page.getByRole('button', { name: /let.?s go/i })
+    await expect(letsGo).toBeVisible({ timeout: 10_000 })
+    await letsGo.click()
+
+    // Step 2 — Character: fill name, click "Looks good →"
+    const nameInput = page.locator('#onboard-name')
+    await expect(nameInput).toBeVisible()
+    await nameInput.fill('E2E Tester')
+    await page.getByRole('button', { name: /looks good/i }).click()
+
+    // Step 3 — Upload guide: "Got it →" button
+    await expect(page.getByRole('button', { name: /got it/i })).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: /got it/i }).click()
+
+    // Step 4 — Ready: "Start learning ⚡" button
+    await expect(page.getByRole('button', { name: /start learning/i })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole('button', { name: /start learning/i }).click()
+
+    // Should land on home after completing wizard
+    await expect(page).toHaveURL('/', { timeout: 15_000 })
+  })
+})
+
+// ── 3. Material Upload ────────────────────────────────────────────────────────
+
+test.describe('Material upload', () => {
+  /**
+   * Tests the upload API route with a minimal PDF-like payload.
+   *
+   * When INGESTION_SERVICE_URL is not set (local dev default) the route returns
+   * a mock 202 so this test validates the API boundary without needing the
+   * full ingestion stack.
+   */
+  test('POST /api/materials/upload returns job_id', async ({ request }) => {
+    const courseId = '00000000-0000-4000-8000-000000000001'
+
+    // Create a minimal file payload (1-byte PDF stub)
+    const buffer = Buffer.from('%PDF-1.4 stub')
+    const formData = new FormData()
+    formData.append('file', new Blob([buffer], { type: 'application/pdf' }), 'lecture.pdf')
+
+    const res = await request.post(`/api/materials/upload?course_id=${courseId}`, {
+      multipart: {
+        file: {
+          name: 'lecture.pdf',
+          mimeType: 'application/pdf',
+          buffer,
+        },
+      },
+    })
+
+    // 202 (mock) or 200/201 (real ingestion service)
+    expect([200, 201, 202]).toContain(res.status())
+    const body = await res.json()
+    expect(body).toHaveProperty('job_id')
+    expect(body).toHaveProperty('material_id')
+  })
+
+  test('upload without course_id returns 400', async ({ request }) => {
+    const res = await request.post('/api/materials/upload', {
+      multipart: {
+        file: {
+          name: 'test.pdf',
+          mimeType: 'application/pdf',
+          buffer: Buffer.from('stub'),
+        },
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+})
+
+// ── 4. Chat with Prof. Nova ───────────────────────────────────────────────────
+
+test.describe('Chat', () => {
+  /**
+   * Sends a message in the chat panel and waits for a non-empty reply.
+   * Uses the auth state so the tutoring service has a valid JWT.
+   */
+  test('sends a message and receives a streamed response', async ({ page }) => {
+    await page.goto('/')
+
+    // Wait for chat panel to render
+    const chatTextarea = page.locator('textarea[placeholder*="Prof Nova"]')
+    await expect(chatTextarea).toBeVisible({ timeout: 15_000 })
+
+    await chatTextarea.fill('What is an atom?')
+    await page.keyboard.press('Enter')
+
+    // Wait for a response mentioning "atom" (streamed from Prof. Nova)
+    await expect(page.locator('text=atom').first()).toBeVisible({ timeout: 30_000 })
+  })
+
+  test('chat API route is reachable and returns a stream', async ({ request }) => {
+    const res = await request.post('/api/chat', {
+      data: {
+        message: 'Hello',
+        conversation_id: null,
+      },
+    })
+    // 200 (streaming) or 401 (unauthenticated request — acceptable, means route exists)
+    expect([200, 401, 403]).toContain(res.status())
+  })
+})
+
+// ── 5. Boss Battle ────────────────────────────────────────────────────────────
+
+test.describe('Boss battle', () => {
+  /**
+   * Navigates to the first boss (The Atom) and initiates a battle.
+   * The battle start may fail against the gaming service (402/500) but the
+   * UI should show the start screen and the button should be clickable.
+   */
+  test('renders boss start screen for /boss-battle/1', async ({ page }) => {
+    await page.goto('/boss-battle/1')
+
+    // Boss name should be rendered
+    await expect(page.locator('text=THE ATOM').or(page.locator('text=The Atom'))).toBeVisible({
+      timeout: 10_000,
+    })
+
+    // Begin Battle button present
+    const beginBtn = page.getByRole('button', { name: /begin battle/i })
+    await expect(beginBtn).toBeVisible()
+  })
+
+  test('clicking Begin Battle calls the gaming service API', async ({ page }) => {
+    await page.goto('/boss-battle/1')
+
+    const beginBtn = page.getByRole('button', { name: /begin battle/i })
+    await expect(beginBtn).toBeVisible({ timeout: 10_000 })
+
+    await beginBtn.click()
+
+    // Wait briefly — button should go loading or UI transitions to battle/error
+    await page.waitForTimeout(2_000)
+
+    // Page must not crash regardless of API outcome
+    await expect(page.locator('body')).toBeVisible()
+  })
+})
+
+// ── 6. Flashcards ─────────────────────────────────────────────────────────────
+
+test.describe('Flashcards', () => {
+  /**
+   * Tests flashcard creation and review via the Next.js API proxy routes.
+   * The gaming-service backend must be running for these to return 200.
+   * On unauthenticated request proxy returns 401 — also acceptable here.
+   */
+  test('GET /api/flashcards returns a list (or 401)', async ({ request }) => {
+    const res = await request.get('/api/flashcards')
+    expect([200, 401]).toContain(res.status())
+    if (res.status() === 200) {
+      const body = await res.json()
+      expect(Array.isArray(body) || typeof body === 'object').toBe(true)
+    }
+  })
+
+  test('GET /api/flashcards/due returns due cards (or 401)', async ({ request }) => {
+    const res = await request.get('/api/flashcards/due')
+    expect([200, 401]).toContain(res.status())
+  })
+
+  test('POST /api/flashcards to generate cards (or 401/422)', async ({ request }) => {
+    const res = await request.post('/api/flashcards', {
+      data: {
+        topic: 'atomic structure',
+        count: 3,
+      },
+    })
+    // 200 success, 401 unauth, 422 invalid payload — all indicate route exists
+    expect([200, 201, 401, 422]).toContain(res.status())
+  })
+
+  test('flashcard review route accepts a rating (or 401/404)', async ({ request }) => {
+    // Use a placeholder card ID — will 404 if not found, 401 if unauth
+    const res = await request.post('/api/flashcards/00000000-0000-4000-8000-000000000001/review', {
+      data: { quality: 4 },
+    })
+    expect([200, 401, 404, 422]).toContain(res.status())
+  })
+})
+
+// ── 7. Leaderboard ────────────────────────────────────────────────────────────
+
+test.describe('Leaderboard', () => {
+  /**
+   * Clicks the Rankings tab in the right sidebar on the home page and
+   * verifies the leaderboard panel renders without crashing.
+   */
+  test('Rankings tab renders leaderboard panel on desktop', async ({ page }) => {
+    // Use desktop viewport — sidebar is hidden on mobile
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto('/')
+
+    // The right sidebar has Mastery / Rankings / Power-ups tabs
+    const rankingsTab = page.getByRole('button', { name: 'Rankings' })
+    await expect(rankingsTab).toBeVisible({ timeout: 10_000 })
+    await rankingsTab.click()
+
+    // After clicking, a leaderboard panel should render (may show loading or data)
+    // We look for the tab to become active and the panel to mount without error
+    await expect(rankingsTab).toHaveClass(/neon-blue|border-neon-blue/, { timeout: 5_000 })
+
+    // No crash — body still visible
+    await expect(page.locator('body')).toBeVisible()
+  })
+
+  test('GET /api/gaming/leaderboard returns data (or 401)', async ({ request }) => {
+    const res = await request.get('/api/gaming/leaderboard')
+    expect([200, 401]).toContain(res.status())
+    if (res.status() === 200) {
+      const body = await res.json()
+      expect(typeof body === 'object').toBe(true)
+    }
+  })
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `e2e/` as a standalone Playwright package targeting the docker-compose stack at `localhost:3000`
- Global setup registers a fresh test user once and saves auth state for all downstream tests
- 16 smoke tests covering 7 journeys: register/login, onboarding wizard, material upload, chat, boss battle, flashcard API, leaderboard

## How to run

```bash
# Start the stack first
docker compose --env-file .env.local up --build

# Then in a separate terminal
cd e2e
npm install
npx playwright install --with-deps chromium
npm test
```

## Test coverage

| Journey | Tests |
|---------|-------|
| Register + Login | UI flow, password mismatch validation |
| Onboarding wizard | All 4 steps, lands on home |
| Material upload | API 202 mock, missing course_id 400 |
| Chat | Send message + receive streamed response, API reachable |
| Boss battle | Start screen renders, Begin Battle click |
| Flashcards | GET list/due, POST generate, rate review (via API proxy) |
| Leaderboard | Rankings tab click, API GET |

Closes tl-c47

🤖 Generated with [Claude Code](https://claude.com/claude-code)