### PR TITLE
feat(tl-dye): boss battle frontend polish — LootReveal (first slice)

### DIFF
--- a/frontend/components/boss/LootReveal.tsx
+++ b/frontend/components/boss/LootReveal.tsx
@@ -80,9 +80,7 @@ export default function LootReveal({
             </span>
             <span className="text-xs font-mono text-text-bright flex-1">{item.label}</span>
             {item.amount !== null && (
-              <span className="text-xs font-mono font-bold text-neon-gold">
-                +{item.amount}
-              </span>
+              <span className="text-xs font-mono font-bold text-neon-gold">+{item.amount}</span>
             )}
           </div>
         )

--- a/frontend/components/boss/LootReveal.tsx
+++ b/frontend/components/boss/LootReveal.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+/**
+ * LootReveal.tsx (tl-dye)
+ *
+ * Post-victory loot reveal panel. Staggers in each reward row with a short
+ * delay so the player sees each prize "drop" individually. Purely presentational
+ * — the parent passes the awarded loot and an `onContinue` callback that is
+ * invoked after all rows have animated in.
+ */
+
+import { useEffect, useState } from 'react'
+
+/** A single loot line item. */
+export interface LootItem {
+  /** Stable key for React list rendering and test targeting. */
+  key: string
+  /** Icon glyph or emoji shown to the left of the label. */
+  icon: string
+  /** Display label (e.g. "Gems", "XP", "Badge: Atom Slayer"). */
+  label: string
+  /** Numeric amount, or null for purely qualitative rewards (badges, etc.). */
+  amount: number | null
+}
+
+export interface LootRevealProps {
+  /** Rewards to show. Order controls the reveal sequence. */
+  items: LootItem[]
+  /** Called once after the final item has revealed. Optional. */
+  onContinue?: () => void
+  /** Ms between each row appearing. Defaults to 400 — lower for tests. */
+  staggerMs?: number
+}
+
+const DEFAULT_STAGGER_MS = 400
+
+/**
+ * LootReveal renders a staggered reveal of post-battle rewards.
+ */
+export default function LootReveal({
+  items,
+  onContinue,
+  staggerMs = DEFAULT_STAGGER_MS,
+}: LootRevealProps) {
+  const [revealed, setRevealed] = useState(0)
+
+  useEffect(() => {
+    if (revealed >= items.length) {
+      onContinue?.()
+      return
+    }
+    const timer = setTimeout(() => setRevealed((n) => n + 1), staggerMs)
+    return () => clearTimeout(timer)
+  }, [revealed, items.length, staggerMs, onContinue])
+
+  return (
+    <div
+      role="region"
+      aria-label="Battle rewards"
+      className="flex flex-col gap-2 w-full max-w-sm mx-auto px-4 py-6 rounded-lg border border-neon-gold/40 bg-bg-panel/60"
+    >
+      <h2 className="text-sm font-mono font-bold text-neon-gold tracking-wider text-center mb-2">
+        LOOT REVEALED
+      </h2>
+      {items.map((item, idx) => {
+        const visible = idx < revealed
+        return (
+          <div
+            key={item.key}
+            data-testid={`loot-row-${item.key}`}
+            aria-hidden={!visible}
+            className={`flex items-center gap-3 px-3 py-2 rounded-md border transition-all duration-300 ${
+              visible
+                ? 'opacity-100 translate-y-0 border-neon-gold/30 bg-neon-gold/5'
+                : 'opacity-0 translate-y-2 border-transparent'
+            }`}
+          >
+            <span aria-hidden="true" className="text-lg">
+              {item.icon}
+            </span>
+            <span className="text-xs font-mono text-text-bright flex-1">{item.label}</span>
+            {item.amount !== null && (
+              <span className="text-xs font-mono font-bold text-neon-gold">
+                +{item.amount}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/components/boss/LootReveal.tsx
+++ b/frontend/components/boss/LootReveal.tsx
@@ -9,7 +9,7 @@
  * invoked after all rows have animated in.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /** A single loot line item. */
 export interface LootItem {
@@ -43,10 +43,17 @@ export default function LootReveal({
   staggerMs = DEFAULT_STAGGER_MS,
 }: LootRevealProps) {
   const [revealed, setRevealed] = useState(0)
+  // Guards against onContinue firing more than once per mount even if the
+  // parent passes a non-memoized callback (effect re-runs when `onContinue`
+  // identity changes).
+  const continueFiredRef = useRef(false)
 
   useEffect(() => {
     if (revealed >= items.length) {
-      onContinue?.()
+      if (!continueFiredRef.current) {
+        continueFiredRef.current = true
+        onContinue?.()
+      }
       return
     }
     const timer = setTimeout(() => setRevealed((n) => n + 1), staggerMs)

--- a/frontend/components/boss/lootReveal.test.tsx
+++ b/frontend/components/boss/lootReveal.test.tsx
@@ -66,6 +66,28 @@ describe('LootReveal', () => {
     expect(badgeRow.textContent).not.toMatch(/\+\d/)
   })
 
+  it('fires onContinue exactly once even when parent re-renders with a new callback identity', () => {
+    const onContinue = jest.fn()
+    const { rerender } = render(<LootReveal items={items} onContinue={onContinue} staggerMs={50} />)
+    for (let i = 0; i < items.length; i++) {
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+    }
+    expect(onContinue).toHaveBeenCalledTimes(1)
+
+    // Simulate a parent re-render that passes a NEW inline function ref.
+    // The effect re-runs (onContinue is in its dep array) but the useRef
+    // guard in LootReveal must suppress a second invocation.
+    const onContinue2 = jest.fn()
+    rerender(<LootReveal items={items} onContinue={onContinue2} staggerMs={50} />)
+    act(() => {
+      jest.advanceTimersByTime(0)
+    })
+    expect(onContinue).toHaveBeenCalledTimes(1)
+    expect(onContinue2).not.toHaveBeenCalled()
+  })
+
   it('handles empty loot list gracefully', () => {
     const onContinue = jest.fn()
     render(<LootReveal items={[]} onContinue={onContinue} staggerMs={50} />)

--- a/frontend/components/boss/lootReveal.test.tsx
+++ b/frontend/components/boss/lootReveal.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen } from '@testing-library/react'
+import LootReveal, { type LootItem } from './LootReveal'
+
+jest.useFakeTimers()
+
+const items: LootItem[] = [
+  { key: 'gems', icon: '💎', label: 'Gems', amount: 25 },
+  { key: 'xp', icon: '⭐', label: 'XP', amount: 120 },
+  { key: 'badge', icon: '🏅', label: 'Badge: Atom Slayer', amount: null },
+]
+
+describe('LootReveal', () => {
+  afterEach(() => {
+    jest.clearAllTimers()
+  })
+
+  it('renders all loot rows with accessible region label', () => {
+    render(<LootReveal items={items} staggerMs={100} />)
+    expect(screen.getByRole('region', { name: /battle rewards/i })).toBeInTheDocument()
+    for (const it of items) {
+      expect(screen.getByTestId(`loot-row-${it.key}`)).toBeInTheDocument()
+    }
+  })
+
+  it('reveals rows in order on each stagger tick', () => {
+    render(<LootReveal items={items} staggerMs={100} />)
+    expect(screen.getByTestId('loot-row-gems')).toHaveAttribute('aria-hidden', 'true')
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(screen.getByTestId('loot-row-gems')).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByTestId('loot-row-xp')).toHaveAttribute('aria-hidden', 'true')
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(screen.getByTestId('loot-row-xp')).toHaveAttribute('aria-hidden', 'false')
+  })
+
+  it('invokes onContinue after the last row reveals', () => {
+    const onContinue = jest.fn()
+    render(<LootReveal items={items} onContinue={onContinue} staggerMs={50} />)
+
+    // Not yet called before any row reveals.
+    expect(onContinue).not.toHaveBeenCalled()
+
+    // Advance one tick per row. Each setTimeout is scheduled by the effect
+    // that ran after the previous state update, so we advance them one at a
+    // time for React to re-run the effect between ticks.
+    for (let i = 0; i < items.length; i++) {
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+    }
+    expect(onContinue).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits amount for qualitative rewards', () => {
+    render(<LootReveal items={items} staggerMs={50} />)
+    const badgeRow = screen.getByTestId('loot-row-badge')
+    expect(badgeRow.textContent).toContain('Badge: Atom Slayer')
+    expect(badgeRow.textContent).not.toMatch(/\+\d/)
+  })
+
+  it('handles empty loot list gracefully', () => {
+    const onContinue = jest.fn()
+    render(<LootReveal items={[]} onContinue={onContinue} staggerMs={50} />)
+    act(() => {
+      jest.advanceTimersByTime(50)
+    })
+    expect(onContinue).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What
First slice of tl-dye (boss battle frontend polish): a self-contained `LootReveal` component with staggered post-victory reward rows, plus unit tests.

## Why
Bead: **tl-dye** — boss battle frontend polish. Scope spans Three.js hit animations, particle effects, realtime state sync (WebSocket/SSE), loot reveal UI, and mobile touch. Splitting into focused commits on one branch; this PR starts with loot UI because it has zero backend coupling and is fully testable in isolation.

## How to test
```bash
cd frontend && npm test -- lootReveal
```
Expect 5 passing tests in `components/boss/lootReveal.test.tsx`.

## Follow-ups on this branch (draft → ready once all land)
- [ ] Wire `LootReveal` into `BossBattleClient` victory phase
- [ ] WebSocket/SSE realtime battle stream hook
- [ ] Integrate `useParticleBurst` / `useScreenShake` / `useComboStreak` into attack phase
- [ ] Mobile touch polish for boss-battle route

## Checklist
- [x] Tests written (TDD) — `components/boss/lootReveal.test.tsx` (5 tests)
- [x] Coverage ≥80% on new code — component fully exercised by tests
- [x] JSDoc on all exports (`LootReveal`, `LootItem`, `LootRevealProps`)
- [x] Lint clean — `npm run lint` passes
- [x] No secrets committed