### PR TITLE
feat(tl-he3): search latency Prometheus histogram

### DIFF
--- a/services/search/app/main.py
+++ b/services/search/app/main.py
@@ -3,13 +3,14 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app.logging_config import configure_logging
 from app.routers import diagrams, search
@@ -61,3 +62,14 @@ async def healthz() -> dict:
         A dict ``{"status": "ok"}`` when the service is running.
     """
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Prometheus scrape endpoint — renders the default registry (tl-he3).
+
+    Returns:
+        Plain-text Prometheus exposition including
+        ``search_query_duration_seconds`` plus any other registered metrics.
+    """
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/search/app/metrics.py
+++ b/services/search/app/metrics.py
@@ -1,0 +1,71 @@
+"""Prometheus metrics for the search service (tl-he3).
+
+Defines the ``search_query_duration_seconds`` histogram and an async
+context manager (:func:`observe_query`) that records an observation with
+the correct ``query_type`` / ``status`` labels whether the wrapped block
+succeeds or raises.
+
+The histogram is defined once at module import time and lives in the
+default prometheus_client REGISTRY, which is what ``prometheus_client.
+generate_latest()`` renders on the ``/metrics`` endpoint in ``main.py``.
+"""
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Literal
+
+from prometheus_client import Histogram
+
+# Buckets chosen per tl-he3 spec: cover expected sub-10ms p50 up through
+# a 2.5s outlier ceiling — anything slower than that is a timeout bug.
+SEARCH_QUERY_DURATION_BUCKETS: tuple[float, ...] = (
+    0.01,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+)
+
+QueryType = Literal["semantic", "keyword", "hybrid"]
+QueryStatus = Literal["success", "error"]
+
+
+SEARCH_QUERY_DURATION = Histogram(
+    "search_query_duration_seconds",
+    "Search query wall-clock duration in seconds, observed at the Qdrant "
+    "RPC call site (semantic/keyword) and at the hybrid router (hybrid).",
+    labelnames=("query_type", "status"),
+    buckets=SEARCH_QUERY_DURATION_BUCKETS,
+)
+
+
+@asynccontextmanager
+async def observe_query(query_type: QueryType) -> AsyncIterator[None]:
+    """Record a single observation in :data:`SEARCH_QUERY_DURATION`.
+
+    Runs ``perf_counter`` around the ``async with`` body. If the body
+    raises, the observation is still recorded with ``status="error"``
+    before the exception propagates — so failed queries do not silently
+    vanish from the histogram.
+
+    Args:
+        query_type: ``"semantic"``, ``"keyword"``, or ``"hybrid"``.
+
+    Yields:
+        ``None`` — the context manager exists only for the side-effect
+        of recording timing.
+    """
+    status: QueryStatus = "success"
+    start = time.perf_counter()
+    try:
+        yield
+    except BaseException:
+        status = "error"
+        raise
+    finally:
+        SEARCH_QUERY_DURATION.labels(
+            query_type=query_type, status=status
+        ).observe(time.perf_counter() - start)

--- a/services/search/app/routers/search.py
+++ b/services/search/app/routers/search.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Query
 
 from app.config import settings
+from app.metrics import observe_query
 from app.models import SearchResponse
 from app.services.embedder import embed_query
 from app.services.hybrid import combine_dense_sparse
@@ -49,13 +50,14 @@ async def search(
     """
     fetch_limit = max(limit, settings.sparse_rerank_limit)
 
-    query_vector, dense_results, sparse_results = await _run_search(
-        q, course_id, fetch_limit, chapter, section, content_type
-    )
+    async with observe_query("hybrid"):
+        query_vector, dense_results, sparse_results = await _run_search(
+            q, course_id, fetch_limit, chapter, section, content_type
+        )
 
-    fused = combine_dense_sparse(dense_results, sparse_results)
-    ranked = await rerank(q, fused)
-    final = ranked[:limit]
+        fused = combine_dense_sparse(dense_results, sparse_results)
+        ranked = await rerank(q, fused)
+        final = ranked[:limit]
 
     search_mode = "hybrid" if sparse_results else "dense"
     return SearchResponse(

--- a/services/search/app/services/qdrant.py
+++ b/services/search/app/services/qdrant.py
@@ -15,6 +15,7 @@ from qdrant_client.models import (
 )
 
 from app.config import settings
+from app.metrics import observe_query
 from app.models import ChunkResult, DiagramResult
 
 logger = logging.getLogger(__name__)
@@ -119,14 +120,15 @@ async def dense_search(
         span.set_attribute("course_id", str(course_id))
         span.set_attribute("limit", limit)
 
-        hits = await client.search(
-            collection_name=settings.curriculum_collection,
-            query_vector=("dense", query_vector),
-            query_filter=query_filter,
-            limit=limit,
-            with_payload=True,
-            with_vectors=False,
-        )
+        async with observe_query("semantic"):
+            hits = await client.search(
+                collection_name=settings.curriculum_collection,
+                query_vector=("dense", query_vector),
+                query_filter=query_filter,
+                limit=limit,
+                with_payload=True,
+                with_vectors=False,
+            )
 
     results = []
     for hit in hits:
@@ -223,17 +225,18 @@ async def sparse_search(
         span.set_attribute("course_id", str(course_id))
         span.set_attribute("limit", limit)
         try:
-            hits = await client.search(
-                collection_name=settings.curriculum_collection,
-                query_vector=NamedSparseVector(
-                    name="sparse",
-                    vector=SparseVector(indices=indices, values=values),
-                ),
-                query_filter=query_filter,
-                limit=limit,
-                with_payload=True,
-                with_vectors=False,
-            )
+            async with observe_query("keyword"):
+                hits = await client.search(
+                    collection_name=settings.curriculum_collection,
+                    query_vector=NamedSparseVector(
+                        name="sparse",
+                        vector=SparseVector(indices=indices, values=values),
+                    ),
+                    query_filter=query_filter,
+                    limit=limit,
+                    with_payload=True,
+                    with_vectors=False,
+                )
         except Exception as exc:
             # Collection may not have sparse vectors indexed yet (pre-ingestion).
             logger.debug("sparse_search skipped (no sparse index?): %s", exc)
@@ -292,14 +295,15 @@ async def diagram_search(
         span.set_attribute("course_id", str(course_id))
         span.set_attribute("limit", limit)
         try:
-            hits = await client.search(
-                collection_name=settings.diagrams_collection,
-                query_vector=query_vector,
-                query_filter=query_filter,
-                limit=limit,
-                with_payload=True,
-                with_vectors=False,
-            )
+            async with observe_query("semantic"):
+                hits = await client.search(
+                    collection_name=settings.diagrams_collection,
+                    query_vector=query_vector,
+                    query_filter=query_filter,
+                    limit=limit,
+                    with_payload=True,
+                    with_vectors=False,
+                )
         except Exception as exc:
             logger.debug("diagram_search unavailable (collection missing?): %s", exc)
             return []

--- a/services/search/requirements.txt
+++ b/services/search/requirements.txt
@@ -8,6 +8,7 @@ openai==1.60.0
 opentelemetry-sdk==1.40.0
 opentelemetry-instrumentation-fastapi==0.61b0
 opentelemetry-exporter-otlp-proto-grpc==1.40.0
+prometheus-client==0.21.0
 
 # Test dependencies
 pytest==8.3.3

--- a/services/search/tests/test_metrics.py
+++ b/services/search/tests/test_metrics.py
@@ -1,0 +1,190 @@
+"""Tests for search-service Prometheus metrics (tl-he3).
+
+Verifies the ``search_query_duration_seconds`` histogram is registered with
+the expected labels/buckets, gets incremented via :func:`observe_query` on
+success and error paths, and is wired into Qdrant call sites plus the
+``/metrics`` endpoint.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.metrics import (
+    SEARCH_QUERY_DURATION,
+    SEARCH_QUERY_DURATION_BUCKETS,
+    observe_query,
+)
+
+COURSE_ID = uuid.uuid4()
+
+
+def _sum(query_type: str, status: str) -> float:
+    """Read the current ``_sum`` counter for a label pair from the registry."""
+    return (
+        SEARCH_QUERY_DURATION.labels(query_type=query_type, status=status)
+        ._sum.get()
+    )
+
+
+def _count(query_type: str, status: str) -> float:
+    """Read the current ``_count`` counter for a label pair."""
+    return (
+        SEARCH_QUERY_DURATION.labels(query_type=query_type, status=status)
+        ._count.get()
+    )
+
+
+class TestHistogramDefinition:
+    """The histogram must match the tl-he3 spec exactly."""
+
+    def test_buckets_match_spec(self) -> None:
+        """Spec requires buckets [.01, .05, .1, .25, .5, 1.0, 2.5]."""
+        assert SEARCH_QUERY_DURATION_BUCKETS == (0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
+
+    def test_label_names(self) -> None:
+        """Labels must be query_type and status in that order."""
+        assert SEARCH_QUERY_DURATION._labelnames == ("query_type", "status")
+
+    def test_metric_name(self) -> None:
+        """Metric name must be search_query_duration_seconds."""
+        assert SEARCH_QUERY_DURATION._name == "search_query_duration_seconds"
+
+
+class TestObserveQuery:
+    """``observe_query`` must record once per call, with correct status label."""
+
+    @pytest.mark.asyncio
+    async def test_success_records_success_label(self) -> None:
+        """Happy path yields status=success."""
+        before = _count("semantic", "success")
+        async with observe_query("semantic"):
+            pass
+        assert _count("semantic", "success") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_error_records_error_label_and_reraises(self) -> None:
+        """Exception path records status=error and propagates."""
+        before = _count("semantic", "error")
+        with pytest.raises(RuntimeError, match="boom"):
+            async with observe_query("semantic"):
+                raise RuntimeError("boom")
+        assert _count("semantic", "error") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_duration_is_positive(self) -> None:
+        """The recorded observation must be > 0 (perf_counter monotonic)."""
+        before = _sum("keyword", "success")
+        async with observe_query("keyword"):
+            pass
+        assert _sum("keyword", "success") > before
+
+
+class TestQdrantCallSitesInstrumented:
+    """Each Qdrant search call site must emit an observation."""
+
+    @pytest.mark.asyncio
+    async def test_dense_search_records_semantic(self) -> None:
+        """dense_search wraps its Qdrant call with observe_query('semantic')."""
+        from app.services import qdrant as q
+
+        before = _count("semantic", "success")
+        fake = MagicMock()
+        fake.search = AsyncMock(return_value=[])
+        with patch.object(q, "get_client", return_value=fake):
+            await q.dense_search([0.0] * 1536, COURSE_ID, limit=3)
+        assert _count("semantic", "success") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_sparse_search_records_keyword(self) -> None:
+        """sparse_search wraps its Qdrant call with observe_query('keyword')."""
+        from app.services import qdrant as q
+
+        before = _count("keyword", "success")
+        fake = MagicMock()
+        fake.search = AsyncMock(return_value=[])
+        with patch.object(q, "get_client", return_value=fake):
+            await q.sparse_search("algebra intro", COURSE_ID, limit=3)
+        assert _count("keyword", "success") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_sparse_search_error_records_keyword_error(self) -> None:
+        """Qdrant failures on the sparse path still produce an observation."""
+        from app.services import qdrant as q
+
+        before = _count("keyword", "error")
+        fake = MagicMock()
+        fake.search = AsyncMock(side_effect=RuntimeError("no sparse index"))
+        with patch.object(q, "get_client", return_value=fake):
+            # sparse_search catches the exception and returns [], but the
+            # observation should still fire with status=error because
+            # observe_query is inside the try.
+            result = await q.sparse_search("x", COURSE_ID, limit=3)
+        assert result == []
+        assert _count("keyword", "error") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_diagram_search_records_semantic(self) -> None:
+        """diagram_search wraps its Qdrant call with observe_query('semantic')."""
+        from app.services import qdrant as q
+
+        before = _count("semantic", "success")
+        fake = MagicMock()
+        fake.search = AsyncMock(return_value=[])
+        with patch.object(q, "get_client", return_value=fake):
+            await q.diagram_search([0.0] * 768, COURSE_ID, limit=3)
+        assert _count("semantic", "success") == before + 1
+
+
+class TestHybridEndpointInstrumented:
+    """The /v1/search endpoint must record a 'hybrid' observation per call."""
+
+    @pytest.mark.asyncio
+    async def test_hybrid_endpoint_records(self) -> None:
+        """End-to-end: a hybrid search increments hybrid/success."""
+        before = _count("hybrid", "success")
+        with (
+            patch(
+                "app.routers.search.embed_query",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 1536,
+            ),
+            patch(
+                "app.routers.search.dense_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "app.routers.search.sparse_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "app.routers.search.rerank",
+                new_callable=AsyncMock,
+                side_effect=lambda q, r: r,
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.get(f"/v1/search?q=hello&course_id={COURSE_ID}")
+                assert resp.status_code == 200
+        assert _count("hybrid", "success") == before + 1
+
+
+class TestMetricsEndpoint:
+    """/metrics must expose the histogram in Prometheus exposition format."""
+
+    def test_metrics_endpoint_exposes_histogram(self) -> None:
+        """The /metrics endpoint must render the histogram for scraping."""
+        with TestClient(app) as client:
+            resp = client.get("/metrics")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "search_query_duration_seconds" in body
+        # Standard histogram sub-series present
+        assert "search_query_duration_seconds_bucket" in body
+        assert "search_query_duration_seconds_count" in body

--- a/services/search/tests/test_metrics.py
+++ b/services/search/tests/test_metrics.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY
 
 from app.main import app
 from app.metrics import (
@@ -23,20 +24,27 @@ from app.metrics import (
 COURSE_ID = uuid.uuid4()
 
 
-def _sum(query_type: str, status: str) -> float:
-    """Read the current ``_sum`` counter for a label pair from the registry."""
-    return (
-        SEARCH_QUERY_DURATION.labels(query_type=query_type, status=status)
-        ._sum.get()
-    )
-
-
 def _count(query_type: str, status: str) -> float:
-    """Read the current ``_count`` counter for a label pair."""
-    return (
-        SEARCH_QUERY_DURATION.labels(query_type=query_type, status=status)
-        ._count.get()
+    """Read the current ``_count`` sample via the global registry.
+
+    Uses ``REGISTRY.get_sample_value`` rather than touching private
+    ``_count`` attributes — labeled histogram children don't expose those
+    directly, which is why the first attempt at this helper failed in CI.
+    """
+    v = REGISTRY.get_sample_value(
+        "search_query_duration_seconds_count",
+        {"query_type": query_type, "status": status},
     )
+    return 0.0 if v is None else v
+
+
+def _sum(query_type: str, status: str) -> float:
+    """Read the current ``_sum`` sample via the global registry."""
+    v = REGISTRY.get_sample_value(
+        "search_query_duration_seconds_sum",
+        {"query_type": query_type, "status": status},
+    )
+    return 0.0 if v is None else v
 
 
 class TestHistogramDefinition:


### PR DESCRIPTION
## What
Adds `search_query_duration_seconds` histogram to the search service.

## Current Behavior
No latency metric emitted — search p95 invisible to Prometheus / RAG SLO alerts.

## New Behavior
- `search_query_duration_seconds{query_type, status}` histogram with spec buckets `[.01, .05, .1, .25, .5, 1.0, 2.5]`.
- `query_type ∈ {semantic, keyword, hybrid}`, `status ∈ {success, error}`.
- `observe_query` async context manager records duration on success and exception paths.
- Wrapped at three Qdrant RPC call sites (dense → semantic, sparse → keyword, diagram → semantic) and at the hybrid router around the full dense+sparse+rerank pipeline.
- `/metrics` endpoint exposes the default prometheus_client registry in standard exposition format.

## Detail
- `services/search/app/metrics.py` — Histogram + `observe_query` CM (exceptions re-raised; observation always recorded via finally).
- `services/search/app/services/qdrant.py` — wrap `await client.search(...)` in each of `dense_search`, `sparse_search`, `diagram_search`.
- `services/search/app/routers/search.py` — wrap hybrid pipeline with `observe_query("hybrid")`.
- `services/search/app/main.py` — `GET /metrics` → `generate_latest()`.
- `services/search/requirements.txt` — `prometheus-client==0.21.0`.

## Why
Bead tl-he3. Search service only emits OTel traces today; RAG-latency SLO alerts (`tl.slo.rag_latency`) need a search-level histogram to distinguish semantic vs keyword vs hybrid tails.

## How to test
- `pytest services/search/tests/test_metrics.py` — bucket shape, label names, success/error paths, all three Qdrant call sites, hybrid endpoint, `/metrics` exposition.
- Manually: hit `/v1/search` then `curl /metrics | grep search_query_duration_seconds`.

## Checklist
- [x] Tests written (TDD) — `tests/test_metrics.py`
- [x] Coverage ≥90% on new code
- [x] Docstrings on all new functions/endpoints
- [x] Lint clean (`ruff check` passes on touched files)
- [x] No secrets committed
- [x] Self-review: diff read before opening

Closes tl-he3