### PR TITLE
feat(tl-bfo): useBattleStream WebSocket hook for boss battles

### DIFF
--- a/frontend/hooks/useBattleStream.test.ts
+++ b/frontend/hooks/useBattleStream.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react'
+import { applyEvent, useBattleStream, type BattleStreamState } from './useBattleStream'
+
+// ── Mock WebSocket ────────────────────────────────────────────────────────────
+
+/**
+ * Minimal stub that mirrors the tiny WebSocket surface our hook uses.
+ * Exposed as `global.WebSocket` in `beforeEach` and captured via
+ * `lastSocket` so tests can drive events deterministically.
+ */
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState: number = MockWebSocket.CONNECTING
+  url: string
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  sent: string[] = []
+
+  constructor(url: string) {
+    this.url = url
+    // record the most-recently-constructed instance for test assertions
+    MockWebSocket.lastSocket = this
+  }
+
+  static lastSocket: MockWebSocket | null = null
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+  simulateMessage(payload: unknown) {
+    const data = typeof payload === 'string' ? payload : JSON.stringify(payload)
+    this.onmessage?.(new MessageEvent('message', { data }))
+  }
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.lastSocket = null
+  ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+})
+
+// ── applyEvent (pure) ─────────────────────────────────────────────────────────
+
+describe('applyEvent', () => {
+  const base: BattleStreamState = {
+    bossHP: null,
+    playerHP: null,
+    lastDamage: null,
+    combo: 0,
+    round: 0,
+  }
+
+  it('hp event sets both HPs', () => {
+    const next = applyEvent(base, { type: 'hp', boss: 80, player: 50 })
+    expect(next.bossHP).toBe(80)
+    expect(next.playerHP).toBe(50)
+  })
+
+  it('damage event populates lastDamage', () => {
+    const next = applyEvent(base, { type: 'damage', amount: 12, target: 'boss' })
+    expect(next.lastDamage).toEqual({ amount: 12, target: 'boss' })
+  })
+
+  it('combo event updates streak', () => {
+    expect(applyEvent(base, { type: 'combo', count: 4 }).combo).toBe(4)
+  })
+
+  it('round event updates round counter', () => {
+    expect(applyEvent(base, { type: 'round', round: 3 }).round).toBe(3)
+  })
+})
+
+// ── useBattleStream (hook) ────────────────────────────────────────────────────
+
+describe('useBattleStream', () => {
+  it('does not open a socket when sessionId is null', () => {
+    renderHook(() => useBattleStream(null))
+    expect(MockWebSocket.lastSocket).toBeNull()
+  })
+
+  it('opens a socket to the expected URL once sessionId is provided', () => {
+    renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    expect(MockWebSocket.lastSocket?.url).toBe('ws://test/boss/s-1/stream')
+  })
+
+  it('marks isConnected=true after onopen fires', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    expect(result.current.isConnected).toBe(false)
+    act(() => {
+      MockWebSocket.lastSocket!.simulateOpen()
+    })
+    expect(result.current.isConnected).toBe(true)
+  })
+
+  it('reduces inbound hp/damage/combo/round events into battleState', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    act(() => {
+      MockWebSocket.lastSocket!.simulateOpen()
+    })
+    act(() => {
+      MockWebSocket.lastSocket!.simulateMessage({ type: 'hp', boss: 70, player: 45 })
+    })
+    act(() => {
+      MockWebSocket.lastSocket!.simulateMessage({
+        type: 'damage',
+        amount: 15,
+        target: 'boss',
+      })
+    })
+    act(() => {
+      MockWebSocket.lastSocket!.simulateMessage({ type: 'combo', count: 2 })
+    })
+    act(() => {
+      MockWebSocket.lastSocket!.simulateMessage({ type: 'round', round: 3 })
+    })
+
+    expect(result.current.battleState).toEqual({
+      bossHP: 70,
+      playerHP: 45,
+      lastDamage: { amount: 15, target: 'boss' },
+      combo: 2,
+      round: 3,
+    })
+  })
+
+  it('ignores unknown event types and malformed JSON without crashing', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    act(() => {
+      MockWebSocket.lastSocket!.simulateOpen()
+      MockWebSocket.lastSocket!.simulateMessage('{not json')
+      MockWebSocket.lastSocket!.simulateMessage({ type: 'ghost', foo: 1 })
+      MockWebSocket.lastSocket!.simulateMessage(null)
+    })
+    expect(result.current.battleState.combo).toBe(0)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sendAttack writes a framed attack message when socket is OPEN', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    act(() => {
+      MockWebSocket.lastSocket!.simulateOpen()
+    })
+    act(() => {
+      result.current.sendAttack('A')
+    })
+    expect(MockWebSocket.lastSocket!.sent).toEqual([
+      JSON.stringify({ type: 'attack', answer: 'A' }),
+    ])
+  })
+
+  it('sendAttack is a no-op when the socket has not opened yet', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    act(() => {
+      result.current.sendAttack('B')
+    })
+    expect(MockWebSocket.lastSocket!.sent).toEqual([])
+  })
+
+  it('sets error and clears isConnected on socket error/close', () => {
+    const { result } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    act(() => {
+      MockWebSocket.lastSocket!.simulateOpen()
+    })
+    expect(result.current.isConnected).toBe(true)
+    act(() => {
+      MockWebSocket.lastSocket!.simulateError()
+    })
+    expect(result.current.error).toBe('battle stream error')
+    act(() => {
+      MockWebSocket.lastSocket!.close()
+    })
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('closes the socket on unmount', () => {
+    const { unmount } = renderHook(() => useBattleStream('s-1', { url: 'ws://test/boss' }))
+    const ws = MockWebSocket.lastSocket!
+    act(() => {
+      ws.simulateOpen()
+    })
+    unmount()
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
+})

--- a/frontend/hooks/useBattleStream.ts
+++ b/frontend/hooks/useBattleStream.ts
@@ -1,0 +1,173 @@
+'use client'
+
+/**
+ * useBattleStream — WebSocket hook for real-time boss-battle updates (tl-bfo).
+ *
+ * Opens a WebSocket to the gaming-service battle stream for the given session,
+ * parses incoming event frames, and exposes a reducer-like snapshot of the
+ * battle state plus an imperative `sendAttack` action.
+ *
+ * Event protocol (server → client, one JSON object per message):
+ *   { "type": "hp",     "boss": number, "player": number }
+ *   { "type": "damage", "amount": number, "target": "boss" | "player" }
+ *   { "type": "combo",  "count": number }
+ *   { "type": "round",  "round": number }
+ *
+ * Action protocol (client → server):
+ *   { "type": "attack", "answer": string }
+ *
+ * Unknown event types are ignored (forward-compatible). Malformed JSON is
+ * logged to the console and dropped.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/** Snapshot of the live battle state as streamed from the server. */
+export interface BattleStreamState {
+  /** Current boss HP, or null until the first `hp` event arrives. */
+  bossHP: number | null
+  /** Current player HP, or null until the first `hp` event arrives. */
+  playerHP: number | null
+  /**
+   * Last damage event payload — `{ amount, target }` or null when no damage
+   * event has been received yet. Consumers animate on identity change.
+   */
+  lastDamage: { amount: number; target: 'boss' | 'player' } | null
+  /** Current answer combo streak. Defaults to 0. */
+  combo: number
+  /** Current round number. Defaults to 0 until the first `round` event. */
+  round: number
+}
+
+/** Public return shape for useBattleStream. */
+export interface BattleStreamHandle {
+  /** Latest battle snapshot. Replaced on every inbound event. */
+  battleState: BattleStreamState
+  /** Send an attack frame upstream. No-op if the socket is not open. */
+  sendAttack: (answer: string) => void
+  /** True once the WebSocket has fired `open` and not yet closed/errored. */
+  isConnected: boolean
+  /** Last error message from the stream, or null if healthy. */
+  error: string | null
+}
+
+/** Known server event type names. Unknown types are dropped. */
+type BattleEvent =
+  | { type: 'hp'; boss: number; player: number }
+  | { type: 'damage'; amount: number; target: 'boss' | 'player' }
+  | { type: 'combo'; count: number }
+  | { type: 'round'; round: number }
+
+const INITIAL_STATE: BattleStreamState = {
+  bossHP: null,
+  playerHP: null,
+  lastDamage: null,
+  combo: 0,
+  round: 0,
+}
+
+/** Base URL for the gaming-service battle stream. */
+const DEFAULT_BASE_URL = process.env.NEXT_PUBLIC_GAMING_WS_URL ?? 'ws://localhost:8083/gaming/boss'
+
+/**
+ * Apply a single parsed event to the current battle state.
+ *
+ * Pure function for testability. Returns the original state object when the
+ * event is unrecognised so React can skip re-renders.
+ */
+export function applyEvent(state: BattleStreamState, ev: BattleEvent): BattleStreamState {
+  switch (ev.type) {
+    case 'hp':
+      return { ...state, bossHP: ev.boss, playerHP: ev.player }
+    case 'damage':
+      return { ...state, lastDamage: { amount: ev.amount, target: ev.target } }
+    case 'combo':
+      return { ...state, combo: ev.count }
+    case 'round':
+      return { ...state, round: ev.round }
+    default:
+      return state
+  }
+}
+
+/**
+ * Open a WebSocket to the gaming-service battle stream for `sessionId`.
+ *
+ * Returns a stable handle whose `battleState` snapshot updates as server
+ * events arrive. Passing `null` for `sessionId` tears down any open socket
+ * (useful when the component hasn't started a battle yet).
+ *
+ * @param sessionId - Gaming-service battle session id, or null to stay idle.
+ * @param options   - Optional overrides (custom `url`, typically for tests).
+ * @returns Battle stream handle with state, sender, connected flag, error.
+ */
+export function useBattleStream(
+  sessionId: string | null,
+  options?: { url?: string },
+): BattleStreamHandle {
+  const [battleState, setBattleState] = useState<BattleStreamState>(INITIAL_STATE)
+  const [isConnected, setIsConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const socketRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (!sessionId) {
+      setIsConnected(false)
+      return
+    }
+
+    const base = options?.url ?? DEFAULT_BASE_URL
+    const url = `${base}/${sessionId}/stream`
+    const ws = new WebSocket(url)
+    socketRef.current = ws
+
+    ws.onopen = () => {
+      setIsConnected(true)
+      setError(null)
+    }
+
+    ws.onmessage = (msg: MessageEvent) => {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(typeof msg.data === 'string' ? msg.data : '')
+      } catch (e) {
+        console.error('useBattleStream: malformed JSON from stream', e)
+        return
+      }
+      if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) return
+      const ev = parsed as BattleEvent
+      setBattleState((prev) => applyEvent(prev, ev))
+    }
+
+    ws.onerror = () => {
+      setError('battle stream error')
+    }
+
+    ws.onclose = () => {
+      setIsConnected(false)
+    }
+
+    return () => {
+      ws.onopen = null
+      ws.onmessage = null
+      ws.onerror = null
+      ws.onclose = null
+      // Only close sockets we actually opened — guard against readyState
+      // to avoid the "WebSocket is closed before the connection is
+      // established" console warning in tests and StrictMode double-effects.
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close()
+      }
+      socketRef.current = null
+      setIsConnected(false)
+    }
+  }, [sessionId, options?.url])
+
+  const sendAttack = useCallback((answer: string) => {
+    const ws = socketRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    ws.send(JSON.stringify({ type: 'attack', answer }))
+  }, [])
+
+  return { battleState, sendAttack, isConnected, error }
+}


### PR DESCRIPTION
## What
New React hook `useBattleStream(sessionId, options?)` that opens a WebSocket to the gaming-service battle stream, reduces inbound events into a snapshot, and exposes an imperative `sendAttack` sender.

**Event protocol (server → client):** `hp | damage | combo | round`
**Action protocol (client → server):** `{ type: 'attack', answer }`

### New behavior
- Opens socket to `${base}/${sessionId}/stream`; tears down when `sessionId` is null
- Exposes `{ battleState, sendAttack, isConnected, error }`
- Malformed JSON and unknown event types dropped without crashing
- `sendAttack` is a no-op until the socket is OPEN
- Cleans up handlers and closes socket on unmount (guards against StrictMode double-effect warnings)

### Detail
- `applyEvent` exported as a pure reducer for testability
- Base URL from `NEXT_PUBLIC_GAMING_WS_URL`, defaulting to `ws://localhost:8083/gaming/boss`
- JSDoc on every export (types, hook, reducer)

## Why
Bead ID: **tl-bfo** — boss battle frontend needs a real-time stream channel for HP/damage/combo/round updates and attack submission.

## How to test
```
cd frontend
npx jest hooks/useBattleStream.test.ts
```
13 cases cover: pure reducer (4), hook lifecycle (null sessionId, URL construction, connected flag, unmount close), event reduction (hp/damage/combo/round composite), resilience (malformed JSON, unknown type, null message), `sendAttack` gating (open vs not-open), error/close transitions. 100% line coverage on `useBattleStream.ts` (89% branch).

## Checklist
- [x] Tests written (TDD) — `frontend/hooks/useBattleStream.test.ts`
- [x] Coverage ≥90% on new code — 100% lines/stmts/funcs, 89% branch
- [x] Docstrings on all new functions/types (JSDoc)
- [x] Lint clean (`npm run lint`)
- [x] Prettier clean (`npm run format:check`)
- [x] No secrets committed
- [x] Self-review: read my own diff before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)