### PR TITLE
feat(tl-j1q): Qdrant snapshot alerting + restore runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,16 @@ jobs:
             fi
           done
           exit $failed
+      - name: Run chart render tests
+        run: |
+          # Each chart may ship a tests/render_test.sh — run them if present.
+          failed=0
+          for script in infra/helm/*/tests/render_test.sh; do
+            [ -f "$script" ] || continue
+            echo "Running ${script}"
+            bash "$script" || { echo "::error::${script} failed"; failed=1; }
+          done
+          exit $failed
 
   # ── Security scan ────────────────────────────────────────────────────────────
   # Always runs on every PR — secrets can appear anywhere.

--- a/docs/runbooks/qdrant-restore.md
+++ b/docs/runbooks/qdrant-restore.md
@@ -1,0 +1,155 @@
+# Qdrant Snapshot Restore Runbook
+
+Runbook for `QdrantSnapshotStale` and `QdrantSnapshotJobFailed` alerts from the
+`tl-qdrant-snapshot-alerts` PrometheusRule (defined in
+`infra/helm/qdrant/templates/prometheusrule-snapshot.yaml`).
+
+- **Alert source:** kube-state-metrics via kube-prometheus-stack
+- **Pager route:** `severity=critical` → PagerDuty; `severity=warning` → Slack `#alerts`
+- **Snapshot artifacts:** `gs://teachers-lounge-qdrant-snapshots/snapshots/<YYYYMMDD-HHMMSS>/<collection>/<file>`
+- **On-call owner:** `bean` (infra) — escalate to Mayor if Dolt/GKE are also impacted.
+
+---
+
+## 1. Triage (first 5 minutes)
+
+Identify which alert fired:
+
+```bash
+# Active alerts
+kubectl -n monitoring port-forward svc/alertmanager-operated 9093 &
+curl -s localhost:9093/api/v2/alerts | jq '.[] | select(.labels.alertname | startswith("QdrantSnapshot"))'
+```
+
+### `QdrantSnapshotJobFailed` (warning)
+
+A single snapshot `Job` owned by the CronJob has failed. The 25h stale-alert
+has **not** yet fired — you have time before on-call is paged. Inspect Job
+logs and decide whether to let the next scheduled run recover or intervene.
+
+### `QdrantSnapshotStale` (critical — pages on-call)
+
+No successful snapshot in the last 25 h. This is the disaster-recovery SLO.
+Do not page-ack and walk away — work the issue until a fresh snapshot lands.
+
+---
+
+## 2. Inspect the CronJob and latest Job
+
+```bash
+kubectl -n teacherslounge get cronjob qdrant-qdrant-snapshot
+kubectl -n teacherslounge get jobs -l app.kubernetes.io/component=snapshot --sort-by=.metadata.creationTimestamp
+kubectl -n teacherslounge logs job/<latest-job-name>
+```
+
+Most common failure modes:
+
+| Symptom in logs                                   | Likely cause                         | Fix                                                      |
+|---------------------------------------------------|--------------------------------------|----------------------------------------------------------|
+| `curl: (7) Failed to connect to qdrant ...`       | Qdrant pods unhealthy                | Check `kubectl get pods -l app.kubernetes.io/name=qdrant` — see §5. |
+| `gsutil ... 403 AccessDenied`                     | Workload Identity binding drifted    | Re-apply the terraform module `infra/terraform/modules/qdrant-gcs`. |
+| `gsutil ... 404 bucket not found`                 | Wrong `snapshot.gcsBucket` per env   | Confirm `values-prod.yaml` override.                     |
+| `activeDeadlineSeconds` exceeded (Job `DeadlineExceeded`) | Snapshot size grew past 2 h budget | Bump `activeDeadlineSeconds` or split by collection.     |
+| `jq: error ... .result.collections`               | Qdrant API contract changed          | Pin Qdrant image tag; file a bead for a migration.       |
+
+---
+
+## 3. List available snapshots in GCS
+
+```bash
+gsutil ls -r gs://teachers-lounge-qdrant-snapshots/snapshots/ | head -40
+
+# Most recent snapshot directory
+LATEST=$(gsutil ls gs://teachers-lounge-qdrant-snapshots/snapshots/ | sort | tail -1)
+echo "latest snapshot set: ${LATEST}"
+gsutil ls -l "${LATEST}"
+```
+
+If `LATEST` is > 25 h old, the page is correct and a manual snapshot must be
+taken **before** any restore (see §4). A restore without a fresh snapshot
+trades one lost window for another.
+
+---
+
+## 4. Trigger a manual snapshot (preferred before any restore)
+
+Always prefer capturing the current state before destructive actions:
+
+```bash
+kubectl -n teacherslounge create job --from=cronjob/qdrant-qdrant-snapshot \
+  qdrant-snapshot-manual-$(date -u +%Y%m%d-%H%M%S)
+
+# Tail the job's logs
+kubectl -n teacherslounge logs -f job/qdrant-snapshot-manual-<ts>
+```
+
+Verify the new snapshot landed in GCS before proceeding.
+
+---
+
+## 5. Restore a collection from a snapshot
+
+Qdrant supports snapshot restore via `PUT /collections/{name}/snapshots/upload`
+with a URL body. The target Qdrant pod must be able to reach the signed URL.
+
+```bash
+# Pick the snapshot to restore
+SNAP_URI="gs://teachers-lounge-qdrant-snapshots/snapshots/20260411-020000/courses/courses-20260411.snapshot"
+COLLECTION="courses"
+
+# Sign a short-lived URL (10 min) so the pod can pull it
+SIGNED=$(gsutil signurl -d 10m -m GET \
+  ~/.config/gcloud/qdrant-snapshots-sa.json "${SNAP_URI}" | tail -1 | awk '{print $NF}')
+
+# Port-forward to one replica (restore is node-local; repeat on each replica)
+kubectl -n teacherslounge port-forward pod/qdrant-qdrant-0 6333:6333 &
+
+curl -X PUT "http://localhost:6333/collections/${COLLECTION}/snapshots/recover" \
+  -H 'Content-Type: application/json' \
+  -d "{\"location\":\"${SIGNED}\"}"
+```
+
+Repeat for each replica (`qdrant-qdrant-0`, `qdrant-qdrant-1`, `qdrant-qdrant-2`).
+Qdrant's distributed mode replicates after the first successful load but
+per-replica restore is faster and avoids replication-lag surprises.
+
+---
+
+## 6. Verify restore
+
+```bash
+curl -s http://localhost:6333/collections/${COLLECTION} | jq '.result | {points_count, status}'
+# points_count should match the snapshot's manifest; status should be "green"
+
+# Smoke-test a known query (uses the ingestion-service health check)
+kubectl -n teacherslounge exec deploy/ingestion-service -- \
+  curl -sf "http://qdrant-qdrant:6333/collections/${COLLECTION}/points/count" \
+  -H 'Content-Type: application/json' -d '{"exact": true}'
+```
+
+Resolve the PagerDuty incident only after both checks pass on **all** replicas.
+
+---
+
+## 7. Rollback
+
+If a restore makes things worse (wrong snapshot, corrupt data), the pre-restore
+state is already captured from §4. Re-run §5 pointing at that manual snapshot.
+
+For a full cluster rebuild (last resort):
+
+```bash
+helm -n teacherslounge uninstall qdrant    # deletes PVCs — destructive
+helm -n teacherslounge install qdrant infra/helm/qdrant \
+  -f infra/helm/qdrant/values-prod.yaml
+# Then restore §5 for each collection.
+```
+
+---
+
+## 8. Post-incident
+
+- Link the PagerDuty incident to the bead tracking the failure.
+- Update this runbook if a new failure mode was encountered (§2 table).
+- If the snapshot CronJob repeatedly fails for the same reason, file a
+  follow-up bead to fix the root cause — do not silence the alert.

--- a/infra/helm/qdrant/templates/prometheusrule-snapshot.yaml
+++ b/infra/helm/qdrant/templates/prometheusrule-snapshot.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.snapshot.enabled .Values.snapshot.alerting.enabled }}
+# PrometheusRule for the nightly Qdrant GCS snapshot CronJob.
+#
+# Two alerts are defined:
+#
+#   QdrantSnapshotStale      severity=critical  → PagerDuty (pages on-call)
+#     Fires when the CronJob's last_successful_time is older than
+#     .Values.snapshot.alerting.stalenessSeconds (default 25h = 90000s).
+#     This is the primary SLO — nightly snapshots must land within 25 h.
+#
+#   QdrantSnapshotJobFailed  severity=warning   → Slack #alerts
+#     Fires when kube-state-metrics reports any failed Job owned by the
+#     snapshot CronJob in the last hour. Early-warning — the CronJob may
+#     still eventually succeed before the 25 h stale-alert trips.
+#
+# Routing is owned by the kube-prometheus-stack alertmanager config in
+# infra/helm/monitoring/values.yaml, which matches on `severity`.
+#
+# Runbook: docs/runbooks/qdrant-restore.md
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "qdrant.fullname" . }}-snapshot-alerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "qdrant.labels" . | nindent 4 }}
+    # Selected by kube-prometheus-stack's default ruleSelector.
+    release: {{ .Values.snapshot.alerting.prometheusReleaseLabel | default "monitoring" }}
+spec:
+  groups:
+    - name: qdrant.snapshot
+      rules:
+        - alert: QdrantSnapshotStale
+          # kube_cronjob_status_last_successful_time is a UNIX timestamp in
+          # seconds, emitted by kube-state-metrics. Compare against `time()`
+          # to measure staleness.  `max by (cronjob)` guards against duplicate
+          # series during kube-state-metrics rollouts.
+          expr: |
+            (time() - max by (cronjob, namespace) (
+              kube_cronjob_status_last_successful_time{
+                cronjob="{{ include "qdrant.fullname" . }}-snapshot",
+                namespace="{{ .Release.Namespace }}"
+              }
+            )) > {{ .Values.snapshot.alerting.stalenessSeconds }}
+          for: {{ .Values.snapshot.alerting.stalenessFor | quote }}
+          labels:
+            severity: critical
+            service: qdrant
+            component: snapshot
+          annotations:
+            summary: "Qdrant nightly snapshot has not succeeded in > 25 h"
+            description: >-
+              The Qdrant snapshot CronJob
+              ({{ "{{" }} $labels.cronjob {{ "}}" }} in namespace
+              {{ "{{" }} $labels.namespace {{ "}}" }}) has not reported a
+              successful completion in over 25 hours. Nightly snapshots are
+              the primary disaster-recovery mechanism for the RAG vector
+              store — this must be investigated immediately.
+            runbook_url: "https://github.com/DreadPirateRobertz/teachers-lounge/blob/main/docs/runbooks/qdrant-restore.md"
+
+        - alert: QdrantSnapshotJobFailed
+          # Any Job owned by the snapshot CronJob that transitioned to failed
+          # in the last hour. Warns before the stale-alert trips at 25 h.
+          expr: |
+            sum by (namespace, job_name) (
+              kube_job_failed{
+                job_name=~"{{ include "qdrant.fullname" . }}-snapshot-.*",
+                namespace="{{ .Release.Namespace }}"
+              }
+            ) > 0
+          for: {{ .Values.snapshot.alerting.jobFailedFor | quote }}
+          labels:
+            severity: warning
+            service: qdrant
+            component: snapshot
+          annotations:
+            summary: "Qdrant snapshot Job failed"
+            description: >-
+              Job {{ "{{" }} $labels.job_name {{ "}}" }} (namespace
+              {{ "{{" }} $labels.namespace {{ "}}" }}) from the Qdrant
+              snapshot CronJob has failed. The 25 h stale-alert will page
+              on-call if the next run does not recover.
+            runbook_url: "https://github.com/DreadPirateRobertz/teachers-lounge/blob/main/docs/runbooks/qdrant-restore.md"
+{{- end }}

--- a/infra/helm/qdrant/tests/render_test.sh
+++ b/infra/helm/qdrant/tests/render_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Render-time tests for the qdrant Helm chart.
+#
+# Exercises the PrometheusRule that alerts on Qdrant snapshot CronJob failures.
+# Run locally:   infra/helm/qdrant/tests/render_test.sh
+# Run in CI:     invoked from .github/workflows/ci.yml (helm-lint job).
+#
+# Each test renders the chart with a distinct values override and asserts on
+# the rendered YAML. Failures abort with a non-zero exit code.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HELM="${HELM:-helm}"
+FAILED=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass() {
+  echo "ok: $*"
+}
+
+render() {
+  # Render with a deterministic release name so kube_cronjob name matches in expr assertions.
+  "$HELM" template qdrant "$CHART_DIR" --namespace teacherslounge "$@"
+}
+
+# ── Test 1: default values render a snapshot PrometheusRule ─────────────────
+out=$(render)
+if ! echo "$out" | grep -q "kind: PrometheusRule"; then
+  fail "default render: expected PrometheusRule, not found"
+else
+  pass "default render includes PrometheusRule"
+fi
+
+# ── Test 2: alert name + 25h threshold present in default render ────────────
+if ! echo "$out" | grep -q "alert: QdrantSnapshotStale"; then
+  fail "default render: expected alert QdrantSnapshotStale"
+else
+  pass "default render includes QdrantSnapshotStale alert"
+fi
+
+if ! echo "$out" | grep -qE "> 25 \* 3600|> 90000"; then
+  fail "default render: expected 25h threshold (25*3600 seconds) in alert expr"
+else
+  pass "default render uses 25h staleness threshold"
+fi
+
+# ── Test 3: severity=critical label is present so PD routing fires ──────────
+if ! echo "$out" | awk '/alert: QdrantSnapshotStale/,/alert: QdrantSnapshotJobFailed/' | grep -q "severity: critical"; then
+  fail "QdrantSnapshotStale must carry severity=critical to route to PagerDuty"
+else
+  pass "QdrantSnapshotStale routes via severity=critical → PagerDuty"
+fi
+
+# ── Test 4: runbook URL annotation points at the restore doc ────────────────
+if ! echo "$out" | grep -q "docs/runbooks/qdrant-restore.md"; then
+  fail "alert is missing runbook_url pointing at docs/runbooks/qdrant-restore.md"
+else
+  pass "alert annotates runbook_url for restore runbook"
+fi
+
+# ── Test 5: job-failure warning alert is present (Slack route) ──────────────
+if ! echo "$out" | grep -q "alert: QdrantSnapshotJobFailed"; then
+  fail "expected QdrantSnapshotJobFailed warning alert for Slack routing"
+else
+  pass "QdrantSnapshotJobFailed warning alert present"
+fi
+
+# ── Test 6: disabling alerting removes the PrometheusRule ───────────────────
+out_no_alert=$(render --set snapshot.alerting.enabled=false)
+if echo "$out_no_alert" | grep -q "kind: PrometheusRule"; then
+  fail "alerting.enabled=false: PrometheusRule should be suppressed"
+else
+  pass "alerting.enabled=false suppresses PrometheusRule"
+fi
+
+# ── Test 7: disabling the CronJob also suppresses alerts ────────────────────
+out_no_snap=$(render --set snapshot.enabled=false)
+if echo "$out_no_snap" | grep -q "kind: PrometheusRule"; then
+  fail "snapshot.enabled=false: PrometheusRule should be suppressed"
+else
+  pass "snapshot.enabled=false suppresses PrometheusRule"
+fi
+
+# ── Test 8: rule scoped to the correct cronjob name (release-aware) ─────────
+# The CronJob name is "{release}-qdrant-snapshot" (include "qdrant.fullname" . ).
+# The CronJob name is the chart fullname + "-snapshot". With release=qdrant
+# (set in `render()`) the helper produces "qdrant-qdrant", so the cronjob
+# label ends up "qdrant-qdrant-snapshot". If the alert's cronjob matcher
+# drifts from the actual CronJob name, the stale-alert silently never fires.
+cronjob_name=$(echo "$out" | awk '/kind: CronJob/{found=1} found && /^  name:/{print $2; exit}')
+if ! echo "$out" | grep -q "cronjob=\"${cronjob_name}\""; then
+  fail "alert expr must scope to cronjob=\"${cronjob_name}\" so it matches the rendered CronJob"
+else
+  pass "alert expr scoped to cronjob=${cronjob_name}"
+fi
+
+# ── Test 9: helm lint passes ────────────────────────────────────────────────
+if "$HELM" lint "$CHART_DIR" >/dev/null 2>&1; then
+  pass "helm lint clean"
+else
+  fail "helm lint reported errors"
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  echo
+  echo "$FAILED test(s) failed" >&2
+  exit 1
+fi
+
+echo
+echo "all qdrant render tests passed"

--- a/infra/helm/qdrant/values.yaml
+++ b/infra/helm/qdrant/values.yaml
@@ -61,6 +61,22 @@ snapshot:
     limits:
       cpu: 500m
       memory: 256Mi
+  ## Prometheus alerting on snapshot freshness + job failures.
+  ## Routing is owned by kube-prometheus-stack alertmanager
+  ## (infra/helm/monitoring/values.yaml):
+  ##   severity=critical → PagerDuty, severity=warning → Slack #alerts.
+  alerting:
+    enabled: true
+    ## Seconds since last successful snapshot before paging. Default 25h
+    ## gives a 1h buffer past the 24h SLO to absorb clock skew / retries.
+    stalenessSeconds: 90000
+    ## `for` window on the stale alert — short, since staleness itself is cumulative.
+    stalenessFor: "5m"
+    ## `for` window on the job-failed warning — absorb single-run transient failures.
+    jobFailedFor: "15m"
+    ## Prometheus release label that kube-prometheus-stack's ruleSelector matches.
+    ## Override when the monitoring chart is deployed under a non-default release name.
+    prometheusReleaseLabel: "monitoring"
 
 ## Service account for Workload Identity (GCS snapshot upload).
 ## In prod, annotate with the GCP service account email.


### PR DESCRIPTION
## What
- Add PrometheusRule at `infra/helm/qdrant/templates/prometheusrule-snapshot.yaml` with two alerts:
  - `QdrantSnapshotStale` (severity=critical → PagerDuty) — fires if `kube_cronjob_status_last_successful_time` is >25h old.
  - `QdrantSnapshotJobFailed` (severity=warning → Slack #alerts) — fires when any Job owned by the snapshot CronJob enters failed state.
- Extend `infra/helm/qdrant/values.yaml` with a `snapshot.alerting.*` block (thresholds are values-driven and overridable per env).
- Add `infra/helm/qdrant/tests/render_test.sh` — 10 assertions covering rule presence, 25h threshold, severity labels, cronjob matcher, runbook URL, and both opt-out paths.
- Wire render tests into `.github/workflows/ci.yml` `helm-lint` job.
- Author `docs/runbooks/qdrant-restore.md` — triage, manual snapshot, per-replica restore, verification, rollback, post-incident.

## Why
Bead: **tl-j1q** (filed locally; ACK'd by petra as the replacement for phantom tl-94n).

Closes the observability gap left by PR #129 (hq-cv-kqszc), which shipped the nightly GCS snapshot CronJob with no alert if it stopped succeeding. Nightly snapshots are the primary DR mechanism for the RAG vector store; silent failure was a latent production risk.

Routing reuses the existing kube-prometheus-stack alertmanager config in `infra/helm/monitoring/values.yaml` (severity=critical → PD, warning → Slack) so **no new secrets or receivers** were introduced.

## How to test
```bash
PATH="$HOME/bin:$PATH" infra/helm/qdrant/tests/render_test.sh
helm lint infra/helm/qdrant
```
Expected: 10 render-test assertions pass, helm lint clean.

## Checklist
- [x] Tests written (TDD) — `infra/helm/qdrant/tests/render_test.sh` (10 assertions; red-green verified locally)
- [x] Coverage ≥90% — every template branch (alerting on/off, snapshot on/off) exercised
- [x] Docstrings — template + values stanzas carry inline rationale; runbook authored
- [x] Lint clean — `helm lint` + render tests pass locally
- [x] No secrets committed
- [x] Self-review — diff reviewed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)