### PR TITLE
chore: prettier --write on 8 unformatted frontend files

### DIFF
--- a/frontend/app/(auth)/register/register.test.tsx
+++ b/frontend/app/(auth)/register/register.test.tsx
@@ -57,12 +57,14 @@ beforeEach(() => {
 })
 
 /** Fill all required fields with valid values and submit the form. */
-function fillAndSubmit(overrides: {
-  displayName?: string
-  email?: string
-  password?: string
-  confirm?: string
-} = {}) {
+function fillAndSubmit(
+  overrides: {
+    displayName?: string
+    email?: string
+    password?: string
+    confirm?: string
+  } = {},
+) {
   const {
     displayName = 'ChemWizard',
     email = 'wizard@test.com',

--- a/frontend/app/adaptive/page.test.tsx
+++ b/frontend/app/adaptive/page.test.tsx
@@ -105,9 +105,7 @@ describe('AdaptiveDashboardPage — unauthenticated', () => {
   it('shows error when no auth cookie is present', async () => {
     clearAuthCookie()
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('adaptive-error')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('adaptive-error')).toBeInTheDocument())
   })
 })
 
@@ -144,30 +142,22 @@ describe('AdaptiveDashboardPage — authenticated', () => {
 
   it('shows the mastery heatmap after data loads', async () => {
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('mastery-heatmap')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('mastery-heatmap')).toBeInTheDocument())
   })
 
   it('shows the upcoming reviews panel after data loads', async () => {
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('upcoming-reviews')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('upcoming-reviews')).toBeInTheDocument())
   })
 
   it('shows the weak concept alerts panel after data loads', async () => {
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('weak-concept-alerts')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('weak-concept-alerts')).toBeInTheDocument())
   })
 
   it('shows the learning style indicator after data loads', async () => {
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('learning-style-indicator')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('learning-style-indicator')).toBeInTheDocument())
   })
 
   it('displays weak concept in alert panel', async () => {
@@ -218,9 +208,7 @@ describe('AdaptiveDashboardPage — fetch error', () => {
 
   it('shows error message when fetch fails', async () => {
     render(<AdaptiveDashboardPage />)
-    await waitFor(() =>
-      expect(screen.getByTestId('adaptive-error')).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByTestId('adaptive-error')).toBeInTheDocument())
   })
 })
 

--- a/frontend/app/adaptive/page.tsx
+++ b/frontend/app/adaptive/page.tsx
@@ -181,10 +181,25 @@ const MASTERY_CONFIG: Record<
   ConceptMastery['mastery_level'],
   { label: string; bg: string; text: string; border: string }
 > = {
-  weak:       { label: 'Weak',       bg: 'bg-red-500/20',     text: 'text-red-400',    border: 'border-red-500/30' },
-  developing: { label: 'Developing', bg: 'bg-yellow-500/15',  text: 'text-yellow-400', border: 'border-yellow-500/30' },
-  strong:     { label: 'Strong',     bg: 'bg-neon-blue/15',   text: 'text-neon-blue',  border: 'border-neon-blue/30' },
-  mastered:   { label: 'Mastered',   bg: 'bg-neon-green/15',  text: 'text-neon-green', border: 'border-neon-green/30' },
+  weak: { label: 'Weak', bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/30' },
+  developing: {
+    label: 'Developing',
+    bg: 'bg-yellow-500/15',
+    text: 'text-yellow-400',
+    border: 'border-yellow-500/30',
+  },
+  strong: {
+    label: 'Strong',
+    bg: 'bg-neon-blue/15',
+    text: 'text-neon-blue',
+    border: 'border-neon-blue/30',
+  },
+  mastered: {
+    label: 'Mastered',
+    bg: 'bg-neon-green/15',
+    text: 'text-neon-green',
+    border: 'border-neon-green/30',
+  },
 }
 
 // ── MasteryHeatmap ────────────────────────────────────────────────────────────
@@ -225,9 +240,7 @@ function MasteryHeatmap({ concepts }: MasteryHeatmapProps) {
                 title={`${c.correct}/${c.total} correct`}
               >
                 <div className="text-[10px] text-text-dim truncate">{c.concept}</div>
-                <div className={`text-xs font-bold font-mono ${cfg.text}`}>
-                  {c.accuracy_pct}%
-                </div>
+                <div className={`text-xs font-bold font-mono ${cfg.text}`}>{c.accuracy_pct}%</div>
               </div>
             )
           })}
@@ -237,14 +250,17 @@ function MasteryHeatmap({ concepts }: MasteryHeatmapProps) {
       {/* Legend */}
       {concepts.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">
-          {(Object.entries(MASTERY_CONFIG) as [ConceptMastery['mastery_level'], typeof MASTERY_CONFIG['weak']][]).map(
-            ([level, cfg]) => (
-              <div key={level} className="flex items-center gap-1">
-                <div className={`w-2 h-2 rounded-full ${cfg.bg} border ${cfg.border}`} />
-                <span className="text-[10px] text-text-dim">{cfg.label}</span>
-              </div>
-            ),
-          )}
+          {(
+            Object.entries(MASTERY_CONFIG) as [
+              ConceptMastery['mastery_level'],
+              (typeof MASTERY_CONFIG)['weak'],
+            ][]
+          ).map(([level, cfg]) => (
+            <div key={level} className="flex items-center gap-1">
+              <div className={`w-2 h-2 rounded-full ${cfg.bg} border ${cfg.border}`} />
+              <span className="text-[10px] text-text-dim">{cfg.label}</span>
+            </div>
+          ))}
         </div>
       )}
     </section>
@@ -260,8 +276,8 @@ interface UpcomingReviewsProps {
 
 /** Badge colour per review priority. */
 const PRIORITY_STYLE: Record<ReviewItem['priority'], string> = {
-  urgent:   'bg-red-500/20 text-red-400 border-red-500/30',
-  soon:     'bg-yellow-500/15 text-yellow-400 border-yellow-500/30',
+  urgent: 'bg-red-500/20 text-red-400 border-red-500/30',
+  soon: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30',
   upcoming: 'bg-neon-blue/10 text-neon-blue border-neon-blue/20',
 }
 
@@ -375,13 +391,23 @@ const DIMENSION_META: Record<
   string,
   { label: string; left: string; right: string; color: string }
 > = {
-  active_reflective: { label: 'Processing',    left: 'Active',     right: 'Reflective', color: '#00aaff' },
-  sensing_intuitive: { label: 'Perception',    left: 'Sensing',    right: 'Intuitive',  color: '#00ff88' },
-  visual_verbal:     { label: 'Input',         left: 'Visual',     right: 'Verbal',     color: '#ff00aa' },
-  sequential_global: { label: 'Understanding', left: 'Sequential', right: 'Global',     color: '#ffdc00' },
+  active_reflective: { label: 'Processing', left: 'Active', right: 'Reflective', color: '#00aaff' },
+  sensing_intuitive: { label: 'Perception', left: 'Sensing', right: 'Intuitive', color: '#00ff88' },
+  visual_verbal: { label: 'Input', left: 'Visual', right: 'Verbal', color: '#ff00aa' },
+  sequential_global: {
+    label: 'Understanding',
+    left: 'Sequential',
+    right: 'Global',
+    color: '#ffdc00',
+  },
 }
 
-const DIMENSION_ORDER = ['active_reflective', 'sensing_intuitive', 'visual_verbal', 'sequential_global']
+const DIMENSION_ORDER = [
+  'active_reflective',
+  'sensing_intuitive',
+  'visual_verbal',
+  'sequential_global',
+]
 
 /**
  * Felder-Silverman learning style profile visualisation.
@@ -405,8 +431,8 @@ function LearningStyleIndicator({ profile }: LearningStyleIndicatorProps) {
       {!hasData ? (
         <div className="text-center py-4">
           <p className="text-xs text-text-dim mb-3">
-            You haven&apos;t completed the learning style assessment yet. It takes ~3 minutes
-            and helps Professor Nova adapt explanations to how you learn best.
+            You haven&apos;t completed the learning style assessment yet. It takes ~3 minutes and
+            helps Professor Nova adapt explanations to how you learn best.
           </p>
           <Link
             href="/assessment"
@@ -421,22 +447,26 @@ function LearningStyleIndicator({ profile }: LearningStyleIndicatorProps) {
             const meta = DIMENSION_META[dim]
             if (!meta) return null
             const value = dials[dim] ?? 0
-            const leftPct  = Math.round(Math.max(0, -value * 50))
+            const leftPct = Math.round(Math.max(0, -value * 50))
             const rightPct = Math.round(Math.max(0, value * 50))
-            const isLeft    = value < -0.1
-            const isRight   = value > 0.1
+            const isLeft = value < -0.1
+            const isRight = value > 0.1
             const isNeutral = !isLeft && !isRight
 
             return (
               <div key={dim}>
                 <div className="flex justify-between items-center mb-1">
-                  <span className={`text-[11px] font-medium ${isLeft ? 'text-text-bright' : 'text-text-dim'}`}>
+                  <span
+                    className={`text-[11px] font-medium ${isLeft ? 'text-text-bright' : 'text-text-dim'}`}
+                  >
                     {meta.left}
                   </span>
                   <span className="text-[10px] text-text-dim uppercase tracking-wider font-mono">
                     {meta.label}
                   </span>
-                  <span className={`text-[11px] font-medium ${isRight ? 'text-text-bright' : 'text-text-dim'}`}>
+                  <span
+                    className={`text-[11px] font-medium ${isRight ? 'text-text-bright' : 'text-text-dim'}`}
+                  >
                     {meta.right}
                   </span>
                 </div>
@@ -446,10 +476,10 @@ function LearningStyleIndicator({ profile }: LearningStyleIndicatorProps) {
                   <div
                     className="absolute inset-0 rounded-full transition-all duration-700"
                     style={{
-                      left:       isLeft  ? `${50 - leftPct}%`  : '50%',
-                      right:      isRight ? `${50 - rightPct}%` : '50%',
+                      left: isLeft ? `${50 - leftPct}%` : '50%',
+                      right: isRight ? `${50 - rightPct}%` : '50%',
                       background: meta.color,
-                      boxShadow:  `0 0 6px ${meta.color}88`,
+                      boxShadow: `0 0 6px ${meta.color}88`,
                     }}
                   />
                   <div className="absolute left-1/2 top-0 bottom-0 w-px bg-border-mid" />
@@ -459,9 +489,7 @@ function LearningStyleIndicator({ profile }: LearningStyleIndicatorProps) {
                   <span className="text-[10px] text-text-dim font-mono">
                     {isLeft ? `${leftPct}%` : ''}
                   </span>
-                  <span className="text-[10px] text-text-dim">
-                    {isNeutral ? 'Balanced' : ''}
-                  </span>
+                  <span className="text-[10px] text-text-dim">{isNeutral ? 'Balanced' : ''}</span>
                   <span className="text-[10px] text-text-dim font-mono">
                     {isRight ? `${rightPct}%` : ''}
                   </span>
@@ -471,10 +499,7 @@ function LearningStyleIndicator({ profile }: LearningStyleIndicatorProps) {
           })}
 
           <div className="pt-1 border-t border-border-dim">
-            <Link
-              href="/assessment"
-              className="text-[11px] text-neon-blue hover:underline"
-            >
+            <Link href="/assessment" className="text-[11px] text-neon-blue hover:underline">
               Retake assessment →
             </Link>
           </div>

--- a/frontend/app/api/flashcards/route.test.ts
+++ b/frontend/app/api/flashcards/route.test.ts
@@ -70,9 +70,9 @@ describe('GET /api/flashcards', () => {
   })
 
   it('forwards upstream status code on error', async () => {
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response(JSON.stringify({ detail: 'not found' }), { status: 404 }),
-    )
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ detail: 'not found' }), { status: 404 }))
 
     const { GET } = await import('./route')
     const resp = await GET(makeGetRequest())
@@ -84,9 +84,7 @@ describe('GET /api/flashcards', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ cards: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ cards: [] }), { status: 200 }))
     })
 
     const { GET } = await import('./route')
@@ -99,9 +97,7 @@ describe('GET /api/flashcards', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ cards: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ cards: [] }), { status: 200 }))
     })
 
     const { GET } = await import('./route')
@@ -117,9 +113,7 @@ describe('GET /api/flashcards', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ cards: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ cards: [] }), { status: 200 }))
     })
 
     const { GET } = await import('./route')
@@ -154,9 +148,9 @@ describe('POST /api/flashcards', () => {
   })
 
   it('forwards upstream status code on POST error', async () => {
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response(JSON.stringify({ error: 'bad request' }), { status: 400 }),
-    )
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'bad request' }), { status: 400 }))
 
     const { POST } = await import('./route')
     const resp = await POST(makePostRequest())
@@ -168,9 +162,7 @@ describe('POST /api/flashcards', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ cards: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ cards: [] }), { status: 200 }))
     })
 
     const { POST } = await import('./route')
@@ -183,9 +175,7 @@ describe('POST /api/flashcards', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ cards: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ cards: [] }), { status: 200 }))
     })
 
     const { POST } = await import('./route')

--- a/frontend/app/api/gaming/progression/route.test.ts
+++ b/frontend/app/api/gaming/progression/route.test.ts
@@ -107,9 +107,7 @@ describe('GET /api/gaming/progression — gaming-service proxy', () => {
   })
 
   it('returns upstream error status when gaming-service fails', async () => {
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response('service unavailable', { status: 503 }),
-    )
+    global.fetch = jest.fn().mockResolvedValue(new Response('service unavailable', { status: 503 }))
 
     const { GET: getProxy } = await import('./route')
     const req = new NextRequest('http://localhost/api/gaming/progression')

--- a/frontend/app/api/gaming/shop/route.test.ts
+++ b/frontend/app/api/gaming/shop/route.test.ts
@@ -121,9 +121,7 @@ describe('GET /api/gaming/shop — gaming-service proxy', () => {
   })
 
   it('returns upstream error status when GET fails', async () => {
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response('upstream error', { status: 502 }),
-    )
+    global.fetch = jest.fn().mockResolvedValue(new Response('upstream error', { status: 502 }))
 
     const { GET: getProxy } = await import('./route')
     const req = new NextRequest('http://localhost/api/gaming/shop')
@@ -138,9 +136,7 @@ describe('GET /api/gaming/shop — gaming-service proxy', () => {
     let capturedHeaders: Record<string, string> = {}
     global.fetch = jest.fn().mockImplementation((_url: string, opts: RequestInit) => {
       capturedHeaders = opts.headers as Record<string, string>
-      return Promise.resolve(
-        new Response(JSON.stringify({ items: [] }), { status: 200 }),
-      )
+      return Promise.resolve(new Response(JSON.stringify({ items: [] }), { status: 200 }))
     })
 
     const { GET: getProxy } = await import('./route')
@@ -188,9 +184,7 @@ describe('POST /api/gaming/shop — gaming-service proxy', () => {
   })
 
   it('returns upstream error status with text body when POST fails', async () => {
-    global.fetch = jest.fn().mockResolvedValue(
-      new Response('insufficient gems', { status: 402 }),
-    )
+    global.fetch = jest.fn().mockResolvedValue(new Response('insufficient gems', { status: 402 }))
 
     const { POST: postProxy } = await import('./route')
     const req = new NextRequest('http://localhost/api/gaming/shop', {

--- a/frontend/app/api/user/profile/[userId]/route.test.ts
+++ b/frontend/app/api/user/profile/[userId]/route.test.ts
@@ -7,10 +7,7 @@ import { NextRequest } from 'next/server'
 
 const MOCK_TOKEN = 'profile-test-token'
 
-function makeRequest(opts: {
-  token?: string | null
-  authHeader?: string
-}): NextRequest {
+function makeRequest(opts: { token?: string | null; authHeader?: string }): NextRequest {
   const headers: Record<string, string> = {}
   if (opts.token !== null) {
     headers['Cookie'] = `tl_token=${opts.token ?? MOCK_TOKEN}`

--- a/frontend/components/chat/chatPanel.test.tsx
+++ b/frontend/components/chat/chatPanel.test.tsx
@@ -258,7 +258,9 @@ describe('ChatPanel', () => {
 
     await waitFor(() => {
       const messages = screen.getAllByTestId('chat-message')
-      const errorMsg = messages.find((el) => el.textContent?.includes('Sorry, something went wrong'))
+      const errorMsg = messages.find((el) =>
+        el.textContent?.includes('Sorry, something went wrong'),
+      )
       expect(errorMsg).toBeTruthy()
     })
   })
@@ -321,7 +323,9 @@ describe('ChatPanel', () => {
 
     // The molecule builder is shown only when isKinesthetic(dials) is true.
     // Since dials=null, it won't show. Verify normal flow completes.
-    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'draw benzene structure' } })
+    fireEvent.change(screen.getByTestId('chat-input'), {
+      target: { value: 'draw benzene structure' },
+    })
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('send-btn'))


### PR DESCRIPTION
## What
Pure formatting chore — ran \`prettier --write\` on 8 files that were failing \`prettier --check\` on main. No logic changes; diff is whitespace/quotes/trailing-comma only.

### Files
- \`app/(auth)/register/register.test.tsx\`
- \`app/adaptive/page.test.tsx\`
- \`app/adaptive/page.tsx\`
- \`app/api/flashcards/route.test.ts\`
- \`app/api/gaming/progression/route.test.ts\`
- \`app/api/gaming/shop/route.test.ts\`
- \`app/api/user/profile/[userId]/route.test.ts\`
- \`components/chat/chatPanel.test.tsx\`

## Why
Unblocks future PRs — \`prettier --check\` currently fails on main for these files, which causes spurious CI failures on unrelated PRs that touch the frontend.

## How to test
\`\`\`
cd frontend
npx prettier --check app/(auth)/register/register.test.tsx app/adaptive/page.test.tsx app/adaptive/page.tsx app/api/flashcards/route.test.ts app/api/gaming/progression/route.test.ts app/api/gaming/shop/route.test.ts "app/api/user/profile/[userId]/route.test.ts" components/chat/chatPanel.test.tsx
\`\`\`

## Checklist
- [x] No logic changes — formatting only
- [x] Prettier clean on listed files
- [x] No secrets committed
- [x] Self-review: diff is whitespace/quotes/commas only

🤖 Generated with [Claude Code](https://claude.com/claude-code)