### PR TITLE
feat(tl-afb): query expansion for short follow-up searches

### DIFF
--- a/services/search/app/config.py
+++ b/services/search/app/config.py
@@ -34,6 +34,13 @@ class Settings(BaseSettings):
     # Number of candidates fetched per signal before RRF fusion + final limit
     sparse_rerank_limit: int = 20
 
+    # Query expansion via AI Gateway (tl-afb) — used for short (<5-token)
+    # follow-up queries when the caller supplies conversation context turns.
+    tutor_fast_model: str = "tutor-fast"
+    query_expansion_short_threshold: int = 5
+    query_expansion_max_context_turns: int = 6
+    query_expansion_max_tokens: int = 128
+
     # Diagram (CLIP) collection — Phase 6 multi-modal RAG
     diagrams_collection: str = "diagrams"
     clip_model: str = "openai/clip-vit-base-patch32"

--- a/services/search/app/config.py
+++ b/services/search/app/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     query_expansion_short_threshold: int = 5
     query_expansion_max_context_turns: int = 6
     query_expansion_max_tokens: int = 128
+    # Hard wall-clock ceiling on the gateway call. Without this, a hung
+    # upstream can stall every short-query search for the OpenAI-client
+    # default (~600s). 3s is well above tutor_fast_model p99 yet leaves
+    # budget for the remainder of the RAG pipeline under its SLO.
+    query_expansion_timeout_seconds: float = 3.0
 
     # Diagram (CLIP) collection — Phase 6 multi-modal RAG
     diagrams_collection: str = "diagrams"

--- a/services/search/app/config.py
+++ b/services/search/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,14 +38,17 @@ class Settings(BaseSettings):
     # Query expansion via AI Gateway (tl-afb) — used for short (<5-token)
     # follow-up queries when the caller supplies conversation context turns.
     tutor_fast_model: str = "tutor-fast"
-    query_expansion_short_threshold: int = 5
-    query_expansion_max_context_turns: int = 6
-    query_expansion_max_tokens: int = 128
+    # Field validators catch misconfigured env overrides at startup instead of
+    # silently producing a feature that never fires (e.g. threshold=0 → always
+    # passthrough_long; timeout=0 → instant failure on every call).
+    query_expansion_short_threshold: int = Field(default=5, ge=1)
+    query_expansion_max_context_turns: int = Field(default=6, ge=1)
+    query_expansion_max_tokens: int = Field(default=128, ge=1, le=1024)
     # Hard wall-clock ceiling on the gateway call. Without this, a hung
     # upstream can stall every short-query search for the OpenAI-client
     # default (~600s). 3s is well above tutor_fast_model p99 yet leaves
     # budget for the remainder of the RAG pipeline under its SLO.
-    query_expansion_timeout_seconds: float = 3.0
+    query_expansion_timeout_seconds: float = Field(default=3.0, gt=0.0)
 
     # Diagram (CLIP) collection — Phase 6 multi-modal RAG
     diagrams_collection: str = "diagrams"

--- a/services/search/app/expander.py
+++ b/services/search/app/expander.py
@@ -106,6 +106,7 @@ async def expand_query(query: str, context_turns: list[str] | None) -> str:
             model=settings.tutor_fast_model,
             messages=prompt,
             max_tokens=settings.query_expansion_max_tokens,
+            timeout=settings.query_expansion_timeout_seconds,
             stream=False,
         )
         expanded = (response.choices[0].message.content or "").strip()

--- a/services/search/app/expander.py
+++ b/services/search/app/expander.py
@@ -70,6 +70,13 @@ async def expand_query(query: str, context_turns: list[str] | None) -> str:
         whenever expansion is skipped or fails. This function is total: it
         never raises; callers can treat its output as a drop-in replacement.
     """
+    # Empty / whitespace-only input has zero tokens so _is_short is True —
+    # guard here so we don't spend a gateway call on a query with no signal
+    # (and never include a blank line in the prompt).
+    if not query.strip():
+        QUERY_EXPANSION_OUTCOMES.labels(outcome="passthrough_nocontext").inc()
+        return query
+
     if not _is_short(query):
         QUERY_EXPANSION_OUTCOMES.labels(outcome="passthrough_long").inc()
         return query

--- a/services/search/app/expander.py
+++ b/services/search/app/expander.py
@@ -1,0 +1,126 @@
+"""Query expansion for short search queries (tl-afb).
+
+A search query of fewer than :data:`app.config.Settings.query_expansion_short_threshold`
+tokens is often an underspecified follow-up like "why?" or "what about it" —
+running it through Qdrant directly retrieves low-relevance chunks. When the
+caller supplies recent conversation turns, we ask the AI gateway
+(``tutor_fast_model``) to rewrite the query into a standalone, self-contained
+question before it hits the retrieval pipeline.
+
+**Design constraints (per tl-afb spec):**
+
+* Stateless — this module owns no session state; the caller supplies
+  ``context_turns`` on every request.
+* Graceful — *any* expansion failure (gateway error, blank output, network
+  timeout) must fall back to the raw query, log a WARNING, and increment the
+  ``search_query_expansion_total`` counter. The search endpoint never 500s on
+  expansion alone.
+* Cheap — expansion is a single non-streaming completion with a small
+  ``max_tokens`` budget.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from app.config import settings
+from app.metrics import QUERY_EXPANSION_OUTCOMES
+
+logger = logging.getLogger(__name__)
+
+_client = None  # lazy AsyncOpenAI pointed at the AI gateway
+
+
+def _get_client():
+    """Return a lazily-initialised AsyncOpenAI client aimed at the AI gateway."""
+    global _client
+    if _client is None:
+        from openai import AsyncOpenAI  # imported here so tests can patch it
+
+        _client = AsyncOpenAI(
+            base_url=settings.ai_gateway_url,
+            api_key=settings.openai_api_key or "ai-gateway-local",
+        )
+    return _client
+
+
+def _is_short(query: str) -> bool:
+    """True if the whitespace-token count is below the configured threshold."""
+    return len(query.split()) < settings.query_expansion_short_threshold
+
+
+def _clip_turns(turns: Iterable[str]) -> list[str]:
+    """Keep the most recent N non-empty turns, bounded by config."""
+    cleaned = [t.strip() for t in turns if t and t.strip()]
+    max_turns = settings.query_expansion_max_context_turns
+    return cleaned[-max_turns:]
+
+
+async def expand_query(query: str, context_turns: list[str] | None) -> str:
+    """Rewrite a short follow-up query into a standalone question.
+
+    Args:
+        query: Raw user query as received by ``/v1/search``.
+        context_turns: Recent conversation turns (caller-supplied, most-recent
+            last). ``None`` or empty means the caller has no context and
+            expansion is skipped.
+
+    Returns:
+        The expanded, self-contained query string — or the original ``query``
+        whenever expansion is skipped or fails. This function is total: it
+        never raises; callers can treat its output as a drop-in replacement.
+    """
+    if not _is_short(query):
+        QUERY_EXPANSION_OUTCOMES.labels(outcome="passthrough_long").inc()
+        return query
+
+    clipped = _clip_turns(context_turns or [])
+    if not clipped:
+        QUERY_EXPANSION_OUTCOMES.labels(outcome="passthrough_nocontext").inc()
+        return query
+
+    prompt = [
+        {
+            "role": "system",
+            "content": (
+                "You rewrite a student's short follow-up question into a "
+                "fully-specified standalone search query, using the prior "
+                "conversation turns for context. Output ONLY the rewritten "
+                "query on a single line — no preamble, no quotation marks, "
+                "no explanations."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Prior conversation turns (oldest → newest):\n"
+                + "\n".join(f"- {t}" for t in clipped)
+                + f"\n\nShort follow-up query: {query}\n\nStandalone query:"
+            ),
+        },
+    ]
+
+    try:
+        client = _get_client()
+        response = await client.chat.completions.create(
+            model=settings.tutor_fast_model,
+            messages=prompt,
+            max_tokens=settings.query_expansion_max_tokens,
+            stream=False,
+        )
+        expanded = (response.choices[0].message.content or "").strip()
+    except Exception:
+        QUERY_EXPANSION_OUTCOMES.labels(outcome="fallback_error").inc()
+        logger.warning(
+            "query expansion failed — falling back to raw query",
+            exc_info=True,
+        )
+        return query
+
+    if not expanded:
+        QUERY_EXPANSION_OUTCOMES.labels(outcome="fallback_blank").inc()
+        logger.warning("query expansion returned blank — falling back to raw query")
+        return query
+
+    QUERY_EXPANSION_OUTCOMES.labels(outcome="expanded").inc()
+    return expanded

--- a/services/search/app/metrics.py
+++ b/services/search/app/metrics.py
@@ -15,7 +15,7 @@ import time
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Literal
 
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 
 # Buckets chosen per tl-he3 spec: cover expected sub-10ms p50 up through
 # a 2.5s outlier ceiling — anything slower than that is a timeout bug.
@@ -69,3 +69,17 @@ async def observe_query(query_type: QueryType) -> AsyncIterator[None]:
         SEARCH_QUERY_DURATION.labels(
             query_type=query_type, status=status
         ).observe(time.perf_counter() - start)
+
+
+# ── Query expansion (tl-afb) ─────────────────────────────────────────────────
+# Counter of short-query expansion outcomes. ``outcome`` values:
+#   - "expanded"   — AI gateway returned a non-empty rewrite that was used
+#   - "passthrough_long"    — query was not short, no expansion attempted
+#   - "passthrough_nocontext" — no context turns supplied, no expansion attempted
+#   - "fallback_blank"      — gateway returned blank output, raw query used
+#   - "fallback_error"      — gateway call raised, raw query used
+QUERY_EXPANSION_OUTCOMES = Counter(
+    "search_query_expansion_total",
+    "Short-query expansion attempts by outcome (tl-afb).",
+    labelnames=("outcome",),
+)

--- a/services/search/app/routers/search.py
+++ b/services/search/app/routers/search.py
@@ -61,8 +61,10 @@ async def search(
 
     When ``q`` is a short follow-up (< ``query_expansion_short_threshold``
     tokens) and ``context_turns`` is non-empty, the query is first rewritten
-    into a standalone form via the AI gateway. Expansion failures silently
-    fall back to the raw query (tl-afb).
+    into a standalone form via the AI gateway. Expansion failures fall back
+    to the raw query, emit a WARNING log, and increment
+    ``search_query_expansion_total{outcome="fallback_error"|"fallback_blank"}``
+    (tl-afb).
     """
     effective_q = await expand_query(q, context_turns)
     fetch_limit = max(limit, settings.sparse_rerank_limit)

--- a/services/search/app/routers/search.py
+++ b/services/search/app/routers/search.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Query
 
 from app.config import settings
+from app.expander import expand_query
 from app.metrics import observe_query
 from app.models import SearchResponse
 from app.services.embedder import embed_query
@@ -39,6 +40,16 @@ async def search(
         int,
         Query(ge=1, le=settings.max_search_limit, description="Max results to return"),
     ] = settings.default_search_limit,
+    context_turns: Annotated[
+        list[str] | None,
+        Query(
+            description=(
+                "Optional recent conversation turns used to expand short "
+                "follow-up queries (tl-afb). Pass as repeated query params: "
+                "&context_turns=... — most-recent turn last."
+            ),
+        ),
+    ] = None,
 ) -> SearchResponse:
     """Hybrid search over the curriculum collection for a given course.
 
@@ -47,21 +58,27 @@ async def search(
 
     Falls back gracefully to dense-only when sparse vectors are not available.
     Supports optional narrowing by chapter, section, and content_type.
+
+    When ``q`` is a short follow-up (< ``query_expansion_short_threshold``
+    tokens) and ``context_turns`` is non-empty, the query is first rewritten
+    into a standalone form via the AI gateway. Expansion failures silently
+    fall back to the raw query (tl-afb).
     """
+    effective_q = await expand_query(q, context_turns)
     fetch_limit = max(limit, settings.sparse_rerank_limit)
 
     async with observe_query("hybrid"):
         query_vector, dense_results, sparse_results = await _run_search(
-            q, course_id, fetch_limit, chapter, section, content_type
+            effective_q, course_id, fetch_limit, chapter, section, content_type
         )
 
         fused = combine_dense_sparse(dense_results, sparse_results)
-        ranked = await rerank(q, fused)
+        ranked = await rerank(effective_q, fused)
         final = ranked[:limit]
 
     search_mode = "hybrid" if sparse_results else "dense"
     return SearchResponse(
-        query=q,
+        query=effective_q,
         course_id=course_id,
         results=final,
         total=len(final),

--- a/services/search/tests/test_expander.py
+++ b/services/search/tests/test_expander.py
@@ -74,6 +74,18 @@ class TestExpandQuery:
         fake.chat.completions.create.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_blank_query_passthrough_no_gateway_call(self) -> None:
+        """Empty / whitespace-only queries must short-circuit before the gateway."""
+        before = _outcome("passthrough_nocontext")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock()
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query("   ", context_turns=["tutor: gas laws"])
+        assert out == "   "
+        assert _outcome("passthrough_nocontext") == before + 1
+        fake.chat.completions.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_long_query_passthrough_no_gateway_call(self) -> None:
         """Queries at/above the token threshold must skip expansion entirely."""
         before = _outcome("passthrough_long")

--- a/services/search/tests/test_expander.py
+++ b/services/search/tests/test_expander.py
@@ -188,7 +188,7 @@ class TestSearchEndpointWiring:
             return results
 
         with (
-            patch("app.expander.expand_query", new_callable=AsyncMock, return_value="What is PV=nRT?"),
+            patch("app.routers.search.expand_query", new_callable=AsyncMock, return_value="What is PV=nRT?"),
             patch("app.routers.search.embed_query", new=_capture_embed),
             patch("app.routers.search.dense_search", new_callable=AsyncMock, return_value=[]),
             patch("app.routers.search.sparse_search", new_callable=AsyncMock, return_value=[]),

--- a/services/search/tests/test_expander.py
+++ b/services/search/tests/test_expander.py
@@ -1,0 +1,259 @@
+"""Tests for the short-query expansion module (tl-afb).
+
+Coverage:
+    * Happy path — short query + context turns → expanded rewrite returned.
+    * Passthrough (long query) — no gateway call, passthrough counter incremented.
+    * Passthrough (no context) — no gateway call, passthrough counter incremented.
+    * Graceful failure — gateway raises or returns blank → raw query + WARNING
+      + ``search_query_expansion_total{outcome="fallback_*"}`` incremented.
+    * Clipping — only the most-recent N turns are sent to the gateway.
+    * Endpoint wiring — ``/v1/search`` uses expanded query through the pipeline.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY
+
+from app import expander
+from app.expander import expand_query
+from app.main import app
+
+COURSE_ID = uuid.uuid4()
+
+
+def _outcome(outcome: str) -> float:
+    """Read the current value of search_query_expansion_total for an outcome."""
+    v = REGISTRY.get_sample_value(
+        "search_query_expansion_total", {"outcome": outcome}
+    )
+    return 0.0 if v is None else v
+
+
+def _fake_completion(text: str) -> SimpleNamespace:
+    """Build a minimal OpenAI-shape chat.completion response containing *text*."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_client():
+    """Ensure each test re-runs the lazy client init — avoids leaked state."""
+    expander._client = None
+    yield
+    expander._client = None
+
+
+class TestExpandQuery:
+    """Unit tests for :func:`app.expander.expand_query`."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_expanded_rewrite(self) -> None:
+        """Short query + context turns should yield the gateway rewrite."""
+        before = _outcome("expanded")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(
+            return_value=_fake_completion("What is the ideal gas law?")
+        )
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query(
+                "why?",
+                context_turns=[
+                    "student: what's PV=nRT used for?",
+                    "tutor: it relates pressure, volume, and temperature for gases.",
+                ],
+            )
+        assert out == "What is the ideal gas law?"
+        assert _outcome("expanded") == before + 1
+        # And the gateway actually got called
+        fake.chat.completions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_long_query_passthrough_no_gateway_call(self) -> None:
+        """Queries at/above the token threshold must skip expansion entirely."""
+        before = _outcome("passthrough_long")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(
+            return_value=_fake_completion("should-not-appear")
+        )
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query(
+                "how does the ideal gas law relate pressure and volume",
+                context_turns=["irrelevant"],
+            )
+        assert out == "how does the ideal gas law relate pressure and volume"
+        assert _outcome("passthrough_long") == before + 1
+        fake.chat.completions.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_context_passthrough(self) -> None:
+        """Short query with empty context must passthrough without a gateway call."""
+        before = _outcome("passthrough_nocontext")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(
+            return_value=_fake_completion("should-not-appear")
+        )
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query("why?", context_turns=None)
+        assert out == "why?"
+        assert _outcome("passthrough_nocontext") == before + 1
+        fake.chat.completions.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blank_turns_treated_as_no_context(self) -> None:
+        """Whitespace-only turns must not trigger a gateway call."""
+        before = _outcome("passthrough_nocontext")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock()
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query("why?", context_turns=["   ", "", "\t\n"])
+        assert out == "why?"
+        assert _outcome("passthrough_nocontext") == before + 1
+        fake.chat.completions.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_gateway_failure_falls_back_to_raw_query(self, caplog) -> None:
+        """Any exception from the gateway must produce raw query + WARNING."""
+        import logging as _logging
+
+        before = _outcome("fallback_error")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(side_effect=RuntimeError("boom"))
+        with (
+            patch.object(expander, "_get_client", return_value=fake),
+            caplog.at_level(_logging.WARNING, logger="app.expander"),
+        ):
+            out = await expand_query("why?", context_turns=["tutor: gas laws"])
+        assert out == "why?"
+        assert _outcome("fallback_error") == before + 1
+        assert any("falling back" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_blank_expansion_falls_back_to_raw_query(self) -> None:
+        """Whitespace-only gateway output must fall back, not propagate."""
+        before = _outcome("fallback_blank")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(return_value=_fake_completion("   "))
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query("why?", context_turns=["tutor: gas laws"])
+        assert out == "why?"
+        assert _outcome("fallback_blank") == before + 1
+
+    @pytest.mark.asyncio
+    async def test_context_is_clipped_to_max(self) -> None:
+        """Only the most-recent ``query_expansion_max_context_turns`` are sent."""
+        from app.config import settings as _settings
+
+        max_turns = _settings.query_expansion_max_context_turns
+        turns = [f"turn-{i}" for i in range(max_turns + 4)]  # 4 extras
+
+        captured: dict = {}
+
+        async def _capture(**kwargs):
+            captured.update(kwargs)
+            return _fake_completion("expanded")
+
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(side_effect=_capture)
+        with patch.object(expander, "_get_client", return_value=fake):
+            await expand_query("why?", context_turns=turns)
+
+        user_msg = captured["messages"][1]["content"]
+        # The oldest turns must have been dropped
+        assert "turn-0" not in user_msg
+        assert "turn-3" not in user_msg
+        # And the newest must be present
+        assert f"turn-{max_turns + 3}" in user_msg
+
+
+class TestSearchEndpointWiring:
+    """End-to-end: ``/v1/search`` uses the expander and propagates the rewrite."""
+
+    @pytest.mark.asyncio
+    async def test_short_query_with_context_is_expanded_in_pipeline(self) -> None:
+        """The effective query downstream (embedder, rerank, response) must be the expansion."""
+        captured: dict[str, str] = {}
+
+        async def _capture_embed(q: str) -> list[float]:
+            captured["embed"] = q
+            return [0.1] * 1536
+
+        async def _capture_rerank(q, results):
+            captured["rerank"] = q
+            return results
+
+        with (
+            patch("app.expander.expand_query", new_callable=AsyncMock, return_value="What is PV=nRT?"),
+            patch("app.routers.search.embed_query", new=_capture_embed),
+            patch("app.routers.search.dense_search", new_callable=AsyncMock, return_value=[]),
+            patch("app.routers.search.sparse_search", new_callable=AsyncMock, return_value=[]),
+            patch("app.routers.search.rerank", new=_capture_rerank),
+        ):
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/v1/search",
+                    params=[
+                        ("q", "why?"),
+                        ("course_id", str(COURSE_ID)),
+                        ("context_turns", "student: PV=nRT?"),
+                        ("context_turns", "tutor: it's the ideal gas law."),
+                    ],
+                )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["query"] == "What is PV=nRT?"
+        assert captured["embed"] == "What is PV=nRT?"
+        assert captured["rerank"] == "What is PV=nRT?"
+
+    @pytest.mark.asyncio
+    async def test_endpoint_never_500s_on_expansion_failure(self) -> None:
+        """Even if the expander module raises, the endpoint must return 200.
+
+        expand_query is total by contract — but if a future refactor breaks
+        that contract, the endpoint should still return results (the router
+        itself is not wrapped in try/except, so this test documents that the
+        expander contract is what protects the endpoint).
+        """
+        # Simulate the real expander being called but gateway failing — the
+        # module's try/except must swallow and return the raw query.
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(side_effect=RuntimeError("gw down"))
+        with (
+            patch.object(expander, "_get_client", return_value=fake),
+            patch(
+                "app.routers.search.embed_query",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 1536,
+            ),
+            patch(
+                "app.routers.search.dense_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "app.routers.search.sparse_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "app.routers.search.rerank",
+                new_callable=AsyncMock,
+                side_effect=lambda q, r: r,
+            ),
+        ):
+            with TestClient(app) as client:
+                resp = client.get(
+                    "/v1/search",
+                    params=[
+                        ("q", "why?"),
+                        ("course_id", str(COURSE_ID)),
+                        ("context_turns", "tutor: gas laws"),
+                    ],
+                )
+        assert resp.status_code == 200
+        assert resp.json()["query"] == "why?"

--- a/services/search/tests/test_expander.py
+++ b/services/search/tests/test_expander.py
@@ -134,6 +134,25 @@ class TestExpandQuery:
         assert any("falling back" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
+    async def test_none_choices_falls_back_via_error_path(self) -> None:
+        """A malformed response with ``choices=None`` must not crash the endpoint.
+
+        Subscripting ``None`` raises ``TypeError`` inside the try block, which
+        must be swallowed by the same graceful-failure guard that handles
+        network errors — pinning the behaviour so a future refactor does not
+        accidentally narrow the ``except`` clause.
+        """
+        before = _outcome("fallback_error")
+        fake = MagicMock()
+        fake.chat.completions.create = AsyncMock(
+            return_value=SimpleNamespace(choices=None)
+        )
+        with patch.object(expander, "_get_client", return_value=fake):
+            out = await expand_query("why?", context_turns=["tutor: gas laws"])
+        assert out == "why?"
+        assert _outcome("fallback_error") == before + 1
+
+    @pytest.mark.asyncio
     async def test_blank_expansion_falls_back_to_raw_query(self) -> None:
         """Whitespace-only gateway output must fall back, not propagate."""
         before = _outcome("fallback_blank")


### PR DESCRIPTION
## What
Adds `app/expander.py` — a short-query expansion path for `/v1/search` that uses caller-supplied conversation turns and the AI-gateway `tutor_fast_model` to rewrite under-specified follow-ups (\"why?\", \"and that one?\") into standalone search queries.

## Current Behavior
Short, ambiguous follow-up queries hit Qdrant directly and retrieve low-relevance chunks.

## New Behavior
- `/v1/search` accepts an optional repeated query param `context_turns` (most-recent last).
- When `q` has fewer than `query_expansion_short_threshold` (=5) whitespace tokens **and** `context_turns` is non-empty, `expand_query()` rewrites it via AI gateway chat completion.
- The **effective** query (expanded or raw) flows through embedding, Qdrant search, rerank, and is echoed on the response.
- Total contract: `expand_query` never raises. Every skip/failure path increments `search_query_expansion_total{outcome}` with `outcome ∈ {expanded, passthrough_long, passthrough_nocontext, fallback_error, fallback_blank}` and logs WARNING on fallbacks.
- Context is clipped to the most-recent `query_expansion_max_context_turns` (=6) to keep gateway payloads bounded.

## Detail
- `app/expander.py` — lazy `AsyncOpenAI` pointed at `ai_gateway_url`, stateless, prompt asks for a single-line standalone rewrite.
- `app/routers/search.py` — adds `context_turns: list[str] | None`; replaces raw `q` with `effective_q` in `_run_search`, `rerank`, and the response `query` field.
- `app/metrics.py` — new `search_query_expansion_total` Counter by `outcome`.
- `app/config.py` — `tutor_fast_model`, `query_expansion_short_threshold`, `query_expansion_max_context_turns`, `query_expansion_max_tokens`.
- `tests/test_expander.py` — 9 tests: happy path / long-query passthrough / no-context passthrough / blank-turns passthrough / gateway error fallback / blank expansion fallback / turn-clipping / endpoint wiring / endpoint resilience on gateway failure.

## Why
Bead tl-afb. Option 1+3 hybrid per petra spec: caller-supplied `context_turns` (stateless) + AI-gateway-backed rewrite. Graceful failure was explicit: never 500 on expansion alone.

## How to test
- `pytest services/search/tests/test_expander.py` — all 9 tests (expander unit + endpoint integration).
- Manually:
  - `curl '.../v1/search?q=hello&course_id=...'` → unchanged behaviour (no context → passthrough).
  - `curl '.../v1/search?q=why?&course_id=...&context_turns=...&context_turns=...'` → query rewritten, `query` in response reflects the rewrite.
  - `curl '.../metrics' | grep search_query_expansion_total` — outcome counters visible.

## Checklist
- [x] Tests written (TDD) — `tests/test_expander.py` (9 cases, expander + endpoint)
- [x] Coverage ≥80% on new code
- [x] Docstrings on all new functions/endpoints/module
- [x] Lint clean (`ruff check` passes on all touched files)
- [x] No secrets committed
- [x] Self-review: diff read before opening

Closes tl-afb