### PR TITLE
fix(gaming-service): suppress errcheck on miniredis mr.Set in streak freeze tests

### DIFF
--- a/services/gaming-service/internal/store/streak_freeze_test.go
+++ b/services/gaming-service/internal/store/streak_freeze_test.go
@@ -150,7 +150,7 @@ func TestIsStreakFrozen_Active(t *testing.T) {
 	ctx := context.Background()
 
 	// Manually insert the freeze key (simulates a prior purchase).
-	mr.Set("streak:freeze:user-bob", "1")
+	_ = mr.Set("streak:freeze:user-bob", "1")
 	mr.SetTTL("streak:freeze:user-bob", 24*time.Hour)
 
 	frozen, err := s.IsStreakFrozen(ctx, "user-bob")
@@ -168,7 +168,7 @@ func TestIsStreakFrozen_Expired(t *testing.T) {
 	s, mr := newFreezeStore(t, &intRow{value: 0})
 	ctx := context.Background()
 
-	mr.Set("streak:freeze:user-carol", "1")
+	_ = mr.Set("streak:freeze:user-carol", "1")
 	mr.SetTTL("streak:freeze:user-carol", 1*time.Second)
 
 	// Fast-forward past the TTL to simulate expiry.


### PR DESCRIPTION
## What
Silence errcheck on mr.Set in streak_freeze_test.go:153,171 via _ =.

## Why
tl-2n5/PR#240 merge introduced unchecked mr.Set calls blocking CI on all PRs touching gaming-service (#238, #241). miniredis Set never errors in test context.

## How to test
cd services/gaming-service && go vet ./... && golangci-lint run ./...

## Checklist
- [x] Lint suppression only — no logic change
- [x] No secrets