### PR TITLE
feat(tl-dye): wire LootReveal into BossBattleClient victory phase

### DIFF
--- a/frontend/components/boss/BossBattleClient.tsx
+++ b/frontend/components/boss/BossBattleClient.tsx
@@ -28,6 +28,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { type AnimationState, type BossVisualDef, getRandomTaunt } from './BossCharacterLibrary'
 import BossHUD, { type PowerUp } from './BossHUD'
 import BattleResolve from './BattleResolve'
+import LootReveal, { type LootItem } from './LootReveal'
 import QuestionCard, { type BattleQuestion } from './QuestionCard'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import useSwipeGesture, { SwipeDirection } from '@/hooks/useSwipeGesture'
@@ -472,7 +473,7 @@ export default function BossBattleClient({ boss, userId, initialGems }: BossBatt
       )}
 
       {/* ── Victory ── */}
-      {phase === 'victory' && <VictoryScreen boss={boss} />}
+      {phase === 'victory' && <VictoryScreen boss={boss} turns={turn} />}
 
       {/* ── Defeat ── */}
       {phase === 'defeat' && <DefeatScreen boss={boss} onRetry={startBattle} />}
@@ -523,7 +524,25 @@ function StartScreen({
   )
 }
 
-function VictoryScreen({ boss }: { boss: BossVisualDef }) {
+/**
+ * Derive client-side victory rewards from the battle outcome.
+ *
+ * Kept pure + exported for unit testing. The backend is the source of truth
+ * for persisted rewards; this is a presentational approximation for the
+ * post-battle reveal. Values are deterministic given `turns` and `boss`.
+ */
+export function computeVictoryLoot(boss: BossVisualDef, turns: number): LootItem[] {
+  const xp = 100 + turns * 10
+  const gems = 25
+  return [
+    { key: 'xp', icon: '⚡', label: 'XP Earned', amount: xp },
+    { key: 'gems', icon: '💎', label: 'Gems', amount: gems },
+    { key: 'badge', icon: '🏅', label: `Badge: ${boss.name} Slayer`, amount: null },
+  ]
+}
+
+function VictoryScreen({ boss, turns }: { boss: BossVisualDef; turns: number }) {
+  const loot = computeVictoryLoot(boss, turns)
   return (
     <div className="flex flex-col items-center gap-4 text-center">
       <div className="text-4xl">🏆</div>
@@ -531,6 +550,7 @@ function VictoryScreen({ boss }: { boss: BossVisualDef }) {
       <p className="text-sm text-text-base font-mono">
         You defeated <span style={{ color: boss.primaryColor }}>{boss.name}</span>
       </p>
+      <LootReveal items={loot} />
       <Link
         href="/"
         className="mt-4 text-sm text-neon-blue border border-neon-blue/30 px-5 py-2 rounded-lg

--- a/frontend/components/boss/computeVictoryLoot.test.ts
+++ b/frontend/components/boss/computeVictoryLoot.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for computeVictoryLoot — the pure loot-derivation helper used by
+ * the victory phase of BossBattleClient (tl-dye).
+ */
+import { computeVictoryLoot } from './BossBattleClient'
+import type { BossVisualDef } from './BossCharacterLibrary'
+
+const fakeBoss = {
+  id: 'the_atom',
+  name: 'The Atom',
+  topic: 'general_chemistry',
+  primaryColor: '#4af',
+  tauntPool: ['electrons everywhere'],
+} as unknown as BossVisualDef
+
+describe('computeVictoryLoot', () => {
+  it('returns XP, gems, and a boss-specific badge in that order', () => {
+    const loot = computeVictoryLoot(fakeBoss, 0)
+    expect(loot.map((l) => l.key)).toEqual(['xp', 'gems', 'badge'])
+  })
+
+  it('scales XP linearly with turns — 100 base + 10 per turn', () => {
+    expect(computeVictoryLoot(fakeBoss, 0)[0].amount).toBe(100)
+    expect(computeVictoryLoot(fakeBoss, 5)[0].amount).toBe(150)
+    expect(computeVictoryLoot(fakeBoss, 20)[0].amount).toBe(300)
+  })
+
+  it('awards a flat gem reward regardless of turns', () => {
+    expect(computeVictoryLoot(fakeBoss, 0)[1].amount).toBe(25)
+    expect(computeVictoryLoot(fakeBoss, 100)[1].amount).toBe(25)
+  })
+
+  it('badge label includes the boss name and has null amount (qualitative)', () => {
+    const badge = computeVictoryLoot(fakeBoss, 3)[2]
+    expect(badge.label).toBe('Badge: The Atom Slayer')
+    expect(badge.amount).toBeNull()
+  })
+
+  it('is deterministic for the same inputs', () => {
+    const a = computeVictoryLoot(fakeBoss, 7)
+    const b = computeVictoryLoot(fakeBoss, 7)
+    expect(a).toEqual(b)
+  })
+})


### PR DESCRIPTION
## What
Wires the \`LootReveal\` panel (merged via PR #219) into the \`BossBattleClient\` victory phase. The static VictoryScreen now renders a staggered reveal of three rewards: XP, gems, and a boss-specific badge.

### New behavior
- Victory phase shows a \`LootReveal\` with XP / gems / badge rows that stagger in
- Extracts \`computeVictoryLoot(boss, turns)\` as an **exported pure helper**:
  - XP: \`100 + turns * 10\` (scales with engagement)
  - Gems: flat \`25\`
  - Badge: \`\"Badge: {boss.name} Slayer\"\`, qualitative (amount = null)

### Detail
- Deliberately client-side derivation — gaming-service doesn't yet expose rewards on the attack/victory payload. When it does, we swap the derivation for the real values; \`LootReveal\` props stay the same.
- VictoryScreen now takes \`turns\` so the XP reward scales with how long the battle went.

## Why
Bead ID: **tl-dye** — boss battle frontend polish. Next slice after PR #219 (LootReveal component) and PR #224 (useBattleStream hook).

## How to test
\`\`\`
cd frontend
npx jest components/boss/computeVictoryLoot.test.ts
npx jest components/boss/  # full boss suite: 209 tests
\`\`\`
5 new cases cover: ordering, XP scaling (0/5/20 turns), flat gem reward, badge label + null amount, determinism.

Manual: start a boss battle, play through to victory, confirm the three loot rows stagger in.

## Checklist
- [x] Tests written (TDD) — \`components/boss/computeVictoryLoot.test.ts\`
- [x] Coverage ≥90% on new code — \`computeVictoryLoot\` 100% branch
- [x] Docstrings on all new functions (JSDoc on \`computeVictoryLoot\`)
- [x] Lint clean (\`npm run lint\`)
- [x] Prettier clean (\`prettier --check\`)
- [x] All 209 boss tests pass
- [x] No secrets committed
- [x] Self-review: read the diff before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)