### PR TITLE
test(tl-3r5): gaming-service store layer coverage ≥90%

### DIFF
--- a/services/gaming-service/internal/store/assessment_coverage_test.go
+++ b/services/gaming-service/internal/store/assessment_coverage_test.go
@@ -1,0 +1,121 @@
+package store_test
+
+// Tests for assessment.go — CreateAssessmentSession, GetAssessmentSession,
+// RecordAssessmentAnswer.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ── assessment session row helper ─────────────────────────────────────────────
+
+// assessmentSessionScanRow returns a funcRow that scans a valid AssessmentSession.
+func assessmentSessionScanRow() pgx.Row {
+	now := time.Now()
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "asess-1"    // id
+		*(dest[1].(*string)) = "user-1"     // user_id
+		*(dest[2].(*string)) = "in_progress" // status
+		*(dest[3].(*int)) = 0               // current_index
+		*(dest[4].(*int)) = 4               // total_questions
+		*(dest[5].(*int)) = 0               // xp_earned
+		*(dest[6].(*[]byte)) = nil           // results (NULL)
+		*(dest[7].(*time.Time)) = now        // started_at
+		*(dest[8].(**time.Time)) = nil       // completed_at
+		return nil
+	}}
+}
+
+// ── CreateAssessmentSession ───────────────────────────────────────────────────
+
+// TestCreateAssessmentSession_HappyPath verifies a session is created and returned.
+func TestCreateAssessmentSession_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{assessmentSessionScanRow()}}
+	s := newMasteryStore(t, db)
+	sess, err := s.CreateAssessmentSession(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("CreateAssessmentSession: %v", err)
+	}
+	if sess.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want user-1", sess.UserID)
+	}
+	if sess.TotalQuestions != 4 {
+		t.Errorf("TotalQuestions: got %d, want 4", sess.TotalQuestions)
+	}
+}
+
+// TestCreateAssessmentSession_DBError_Propagated verifies scan errors are returned.
+func TestCreateAssessmentSession_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("insert failed")
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}}
+	s := newMasteryStore(t, db)
+	_, err := s.CreateAssessmentSession(context.Background(), "user-1")
+	if !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped DB error, got %v", err)
+	}
+}
+
+// ── GetAssessmentSession ──────────────────────────────────────────────────────
+
+// TestGetAssessmentSession_HappyPath verifies a session is returned by ID.
+func TestGetAssessmentSession_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{assessmentSessionScanRow()}}
+	s := newMasteryStore(t, db)
+	sess, err := s.GetAssessmentSession(context.Background(), "asess-1")
+	if err != nil {
+		t.Fatalf("GetAssessmentSession: %v", err)
+	}
+	if sess.ID != "asess-1" {
+		t.Errorf("ID: got %q, want asess-1", sess.ID)
+	}
+}
+
+// TestGetAssessmentSession_NotFound_ReturnsError verifies that ErrNoRows is
+// wrapped and returned (not swallowed).
+func TestGetAssessmentSession_NotFound_ReturnsError(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(pgx.ErrNoRows)}}
+	s := newMasteryStore(t, db)
+	_, err := s.GetAssessmentSession(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for missing session, got nil")
+	}
+}
+
+// ── RecordAssessmentAnswer — error paths ──────────────────────────────────────
+
+// TestRecordAssessmentAnswer_BeginError_Propagated verifies Begin failures surface.
+func TestRecordAssessmentAnswer_BeginError_Propagated(t *testing.T) {
+	beginErr := errors.New("pool exhausted")
+	s := newMasteryStore(t, &txDB{txErr: beginErr})
+	_, err := s.RecordAssessmentAnswer(context.Background(), "sess-1", "user-1", "q-1", "A")
+	if !errors.Is(err, beginErr) {
+		t.Errorf("expected begin error, got %v", err)
+	}
+}
+
+// TestRecordAssessmentAnswer_ExecError_Propagated verifies INSERT answer failures surface.
+func TestRecordAssessmentAnswer_ExecError_Propagated(t *testing.T) {
+	execErr := errors.New("insert answer failed")
+	tx := &mockTx{execErr: execErr}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.RecordAssessmentAnswer(context.Background(), "sess-1", "user-1", "q-1", "A")
+	if err == nil {
+		t.Fatal("expected error from Exec failure, got nil")
+	}
+}
+
+// TestRecordAssessmentAnswer_SelectError_Propagated verifies SELECT FOR UPDATE failures surface.
+func TestRecordAssessmentAnswer_SelectError_Propagated(t *testing.T) {
+	selectErr := errors.New("select failed")
+	tx := &txWithQueryRow{mockTx: &mockTx{}, queryRow: errFuncRow(selectErr)}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.RecordAssessmentAnswer(context.Background(), "sess-1", "user-1", "q-1", "A")
+	if err == nil {
+		t.Fatal("expected error from SELECT failure, got nil")
+	}
+}

--- a/services/gaming-service/internal/store/battle_coverage_test.go
+++ b/services/gaming-service/internal/store/battle_coverage_test.go
@@ -52,26 +52,26 @@ func (t *txWithQueryRow) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row
 // ── txDB ──────────────────────────────────────────────────────────────────────
 
 type txDB struct {
-	tx     pgx.Tx
-	txErr  error
-	intRow pgx.Row
+	tx        pgx.Tx
+	txErr     error
+	battleRow pgx.Row
 }
 
 func (d *txDB) Begin(_ context.Context) (pgx.Tx, error) { return d.tx, d.txErr }
-func (d *txDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return d.intRow }
+func (d *txDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return d.battleRow }
 func (d *txDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
 func (d *txDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
 }
 
-// ── intRow ────────────────────────────────────────────────────────────────────
+// ── battleIntRow ──────────────────────────────────────────────────────────────
 
-type intRow struct {
+type battleIntRow struct {
 	value int
 	err   error
 }
 
-func (r *intRow) Scan(dest ...any) error {
+func (r *battleIntRow) Scan(dest ...any) error {
 	if r.err != nil {
 		return r.err
 	}
@@ -240,7 +240,7 @@ func TestRecordBattleResult_CommitError_Propagated(t *testing.T) {
 // ── DeductGems ────────────────────────────────────────────────────────────────
 
 func TestDeductGems_HappyPath(t *testing.T) {
-	s := newBattleStore(t, &txDB{intRow: &intRow{value: 90}})
+	s := newBattleStore(t, &txDB{battleRow: &battleIntRow{value: 90}})
 	remaining, err := s.DeductGems(context.Background(), "user-abc", 10)
 	if err != nil {
 		t.Fatalf("DeductGems: %v", err)
@@ -251,7 +251,7 @@ func TestDeductGems_HappyPath(t *testing.T) {
 }
 
 func TestDeductGems_InsufficientGems_ReturnsError(t *testing.T) {
-	s := newBattleStore(t, &txDB{intRow: &intRow{err: errors.New("no rows")}})
+	s := newBattleStore(t, &txDB{battleRow: &battleIntRow{err: errors.New("no rows")}})
 	if _, err := s.DeductGems(context.Background(), "user-abc", 999); err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/services/gaming-service/internal/store/battle_coverage_test.go
+++ b/services/gaming-service/internal/store/battle_coverage_test.go
@@ -1,0 +1,258 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/teacherslounge/gaming-service/internal/model"
+	"github.com/teacherslounge/gaming-service/internal/store"
+)
+
+// ── pgx.Tx mock ───────────────────────────────────────────────────────────────
+
+type mockTx struct {
+	execErr   error
+	commitErr error
+	execCalls int
+}
+
+func (t *mockTx) Begin(_ context.Context) (pgx.Tx, error)  { return t, nil }
+func (t *mockTx) Commit(_ context.Context) error            { return t.commitErr }
+func (t *mockTx) Rollback(_ context.Context) error          { return nil }
+func (t *mockTx) Conn() *pgx.Conn                           { return nil }
+func (t *mockTx) LargeObjects() pgx.LargeObjects            { return pgx.LargeObjects{} }
+func (t *mockTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults { return nil }
+func (t *mockTx) Prepare(_ context.Context, _, _ string) (*pgconn.StatementDescription, error) {
+	return nil, nil
+}
+func (t *mockTx) CopyFrom(_ context.Context, _ pgx.Identifier, _ []string, _ pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+func (t *mockTx) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
+func (t *mockTx) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row        { return nil }
+func (t *mockTx) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	t.execCalls++
+	return pgconn.CommandTag{}, t.execErr
+}
+
+// txWithQueryRow extends mockTx so tests can inject a row response.
+type txWithQueryRow struct {
+	*mockTx
+	queryRow pgx.Row
+}
+
+func (t *txWithQueryRow) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return t.queryRow
+}
+
+// ── txDB ──────────────────────────────────────────────────────────────────────
+
+type txDB struct {
+	tx     pgx.Tx
+	txErr  error
+	intRow pgx.Row
+}
+
+func (d *txDB) Begin(_ context.Context) (pgx.Tx, error) { return d.tx, d.txErr }
+func (d *txDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return d.intRow }
+func (d *txDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
+func (d *txDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+// ── intRow ────────────────────────────────────────────────────────────────────
+
+type intRow struct {
+	value int
+	err   error
+}
+
+func (r *intRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*(dest[0].(*int)) = r.value
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newBattleStore(t *testing.T, db store.DB) *store.Store {
+	t.Helper()
+	return newMasteryStore(t, db)
+}
+
+func battleSession(id string) *model.BattleSession {
+	return &model.BattleSession{
+		SessionID: id,
+		UserID:    "user-abc",
+		BossID:    "the_atom",
+		Phase:     model.PhaseActive,
+		PlayerHP:  100,
+		BossHP:    80,
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+}
+
+// ── SaveBattleSession ─────────────────────────────────────────────────────────
+
+func TestSaveBattleSession_HappyPath(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	if err := s.SaveBattleSession(context.Background(), battleSession("sess-1")); err != nil {
+		t.Fatalf("SaveBattleSession: %v", err)
+	}
+}
+
+func TestSaveBattleSession_ExpiredExpiresAt_UsesFallbackTTL(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	sess := battleSession("sess-exp")
+	sess.ExpiresAt = time.Now().Add(-5 * time.Minute)
+	if err := s.SaveBattleSession(context.Background(), sess); err != nil {
+		t.Fatalf("SaveBattleSession: %v", err)
+	}
+	got, err := s.GetBattleSession(context.Background(), "sess-exp")
+	if err != nil {
+		t.Fatalf("GetBattleSession: %v", err)
+	}
+	if got == nil {
+		t.Error("expected session to be stored, got nil")
+	}
+}
+
+// ── GetBattleSession ──────────────────────────────────────────────────────────
+
+func TestGetBattleSession_HappyPath(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	sess := battleSession("sess-2")
+	if err := s.SaveBattleSession(context.Background(), sess); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.GetBattleSession(context.Background(), "sess-2")
+	if err != nil {
+		t.Fatalf("GetBattleSession: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil session")
+	}
+	if got.SessionID != "sess-2" {
+		t.Errorf("SessionID: got %q, want sess-2", got.SessionID)
+	}
+}
+
+func TestGetBattleSession_NotFound_ReturnsNil(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	got, err := s.GetBattleSession(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+// ── DeleteBattleSession ───────────────────────────────────────────────────────
+
+func TestDeleteBattleSession_RemovesKey(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	sess := battleSession("sess-del")
+	if err := s.SaveBattleSession(context.Background(), sess); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := s.DeleteBattleSession(context.Background(), "sess-del"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, err := s.GetBattleSession(context.Background(), "sess-del")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestDeleteBattleSession_MissingKey_NoError(t *testing.T) {
+	s := newBattleStore(t, &txDB{})
+	if err := s.DeleteBattleSession(context.Background(), "never-existed"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ── RecordBattleResult ────────────────────────────────────────────────────────
+
+func TestRecordBattleResult_Victory_ExecsInsertAndUpdate(t *testing.T) {
+	tx := &mockTx{}
+	s := newBattleStore(t, &txDB{tx: tx})
+	result := &model.BattleResult{
+		SessionID: "sess-win", UserID: "u", BossID: "b",
+		Won: true, TurnsUsed: 5, XPEarned: 100, GemsEarned: 10,
+		FinishedAt: time.Now(),
+	}
+	if err := s.RecordBattleResult(context.Background(), result); err != nil {
+		t.Fatalf("RecordBattleResult: %v", err)
+	}
+	if tx.execCalls != 2 {
+		t.Errorf("want 2 Exec calls for victory, got %d", tx.execCalls)
+	}
+}
+
+func TestRecordBattleResult_Defeat_ExecsInsertOnly(t *testing.T) {
+	tx := &mockTx{}
+	s := newBattleStore(t, &txDB{tx: tx})
+	result := &model.BattleResult{
+		UserID: "u", BossID: "b", Won: false, FinishedAt: time.Now(),
+	}
+	if err := s.RecordBattleResult(context.Background(), result); err != nil {
+		t.Fatalf("RecordBattleResult: %v", err)
+	}
+	if tx.execCalls != 1 {
+		t.Errorf("want 1 Exec call for defeat, got %d", tx.execCalls)
+	}
+}
+
+func TestRecordBattleResult_BeginError_Propagated(t *testing.T) {
+	beginErr := errors.New("pool exhausted")
+	s := newBattleStore(t, &txDB{txErr: beginErr})
+	if err := s.RecordBattleResult(context.Background(), &model.BattleResult{FinishedAt: time.Now()}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRecordBattleResult_ExecError_Propagated(t *testing.T) {
+	tx := &mockTx{execErr: errors.New("constraint")}
+	s := newBattleStore(t, &txDB{tx: tx})
+	if err := s.RecordBattleResult(context.Background(), &model.BattleResult{Won: true, FinishedAt: time.Now()}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRecordBattleResult_CommitError_Propagated(t *testing.T) {
+	tx := &mockTx{commitErr: errors.New("commit failed")}
+	s := newBattleStore(t, &txDB{tx: tx})
+	if err := s.RecordBattleResult(context.Background(), &model.BattleResult{FinishedAt: time.Now()}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ── DeductGems ────────────────────────────────────────────────────────────────
+
+func TestDeductGems_HappyPath(t *testing.T) {
+	s := newBattleStore(t, &txDB{intRow: &intRow{value: 90}})
+	remaining, err := s.DeductGems(context.Background(), "user-abc", 10)
+	if err != nil {
+		t.Fatalf("DeductGems: %v", err)
+	}
+	if remaining != 90 {
+		t.Errorf("remaining: got %d, want 90", remaining)
+	}
+}
+
+func TestDeductGems_InsufficientGems_ReturnsError(t *testing.T) {
+	s := newBattleStore(t, &txDB{intRow: &intRow{err: errors.New("no rows")}})
+	if _, err := s.DeductGems(context.Background(), "user-abc", 999); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/services/gaming-service/internal/store/extra_coverage_test.go
+++ b/services/gaming-service/internal/store/extra_coverage_test.go
@@ -136,7 +136,7 @@ func TestReviewFlashcard_CommitError_Propagated(t *testing.T) {
 func TestGetHintIndex_ExistingKey_ReturnsParsedCount(t *testing.T) {
 	s, mr := newStoreWithRedis(t, &execDB{})
 	// Seed Redis directly via miniredis.
-	mr.Set("quiz:hints:sess-1:q-1", "3")
+	_ = mr.Set("quiz:hints:sess-1:q-1", "3")
 	n, err := s.GetHintIndex(context.Background(), "sess-1", "q-1")
 	if err != nil {
 		t.Fatalf("GetHintIndex: %v", err)

--- a/services/gaming-service/internal/store/extra_coverage_test.go
+++ b/services/gaming-service/internal/store/extra_coverage_test.go
@@ -1,0 +1,164 @@
+package store_test
+
+// Extra coverage tests targeting the highest-gap functions:
+// RecordAssessmentAnswer (happy path), ReviewFlashcard (happy path),
+// GetHintIndex (key found), RecordAnswer (commit error).
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/redis/go-redis/v9"
+	"github.com/teacherslounge/gaming-service/internal/store"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// newStoreWithRedis creates a Store backed by a miniredis instance and returns
+// both so callers can seed Redis state before the function under test is called.
+func newStoreWithRedis(t *testing.T, db store.DB) (*store.Store, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	return store.New(db, rdb), mr
+}
+
+// txWithRowQueue extends mockTx with a FIFO queue of QueryRow responses.
+// Each call to QueryRow pops the next row; once exhausted returns errFuncRow.
+type txWithRowQueue struct {
+	*mockTx
+	rows []pgx.Row
+	idx  int
+}
+
+func (t *txWithRowQueue) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if t.idx >= len(t.rows) {
+		return errFuncRow(errors.New("txWithRowQueue: no more rows"))
+	}
+	r := t.rows[t.idx]
+	t.idx++
+	return r
+}
+
+// ── RecordAssessmentAnswer — happy path (non-last question) ───────────────────
+
+// TestRecordAssessmentAnswer_NotLastQuestion_HappyPath covers the else branch:
+// the session has more questions remaining, so only current_index is advanced.
+func TestRecordAssessmentAnswer_NotLastQuestion_HappyPath(t *testing.T) {
+	// Both QueryRow calls (SELECT FOR UPDATE and UPDATE current_index RETURNING)
+	// return the same assessment session row, which is fine for this test.
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{},
+		rows:   []pgx.Row{assessmentSessionScanRow(), assessmentSessionScanRow()},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	sess, err := s.RecordAssessmentAnswer(context.Background(), "asess-1", "user-1", "q-1", "A")
+	if err != nil {
+		t.Fatalf("RecordAssessmentAnswer: %v", err)
+	}
+	if sess.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want user-1", sess.UserID)
+	}
+}
+
+// TestRecordAssessmentAnswer_CommitError_Propagated covers the Commit failure path.
+func TestRecordAssessmentAnswer_CommitError_Propagated(t *testing.T) {
+	commitErr := errors.New("commit failed")
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{commitErr: commitErr},
+		rows:   []pgx.Row{assessmentSessionScanRow(), assessmentSessionScanRow()},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.RecordAssessmentAnswer(context.Background(), "asess-1", "user-1", "q-1", "A")
+	if !errors.Is(err, commitErr) {
+		t.Errorf("expected commit error, got %v", err)
+	}
+}
+
+// ── ReviewFlashcard — happy path ──────────────────────────────────────────────
+
+// TestReviewFlashcard_HappyPath covers the SELECT → INSERT review → UPDATE path.
+func TestReviewFlashcard_HappyPath(t *testing.T) {
+	// QueryRow is called twice: SELECT FOR UPDATE and UPDATE RETURNING.
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{},
+		rows:   []pgx.Row{flashcardScanRow(), flashcardScanRow()},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	card, err := s.ReviewFlashcard(context.Background(), "card-1", "user-1", 4)
+	if err != nil {
+		t.Fatalf("ReviewFlashcard: %v", err)
+	}
+	if card.ID != "card-1" {
+		t.Errorf("card.ID: got %q, want card-1", card.ID)
+	}
+}
+
+// TestReviewFlashcard_UpdateError_Propagated covers scan failure on the UPDATE row.
+func TestReviewFlashcard_UpdateError_Propagated(t *testing.T) {
+	updateErr := errors.New("update failed")
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{},
+		rows:   []pgx.Row{flashcardScanRow(), errFuncRow(updateErr)},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.ReviewFlashcard(context.Background(), "card-1", "user-1", 4)
+	if !errors.Is(err, updateErr) {
+		t.Errorf("expected update error, got %v", err)
+	}
+}
+
+// TestReviewFlashcard_CommitError_Propagated covers Commit failure.
+func TestReviewFlashcard_CommitError_Propagated(t *testing.T) {
+	commitErr := errors.New("commit failed")
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{commitErr: commitErr},
+		rows:   []pgx.Row{flashcardScanRow(), flashcardScanRow()},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.ReviewFlashcard(context.Background(), "card-1", "user-1", 4)
+	if !errors.Is(err, commitErr) {
+		t.Errorf("expected commit error, got %v", err)
+	}
+}
+
+// ── GetHintIndex — key exists ─────────────────────────────────────────────────
+
+// TestGetHintIndex_ExistingKey_ReturnsParsedCount verifies that an existing key
+// in Redis returns the stored integer value.
+func TestGetHintIndex_ExistingKey_ReturnsParsedCount(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &execDB{})
+	// Seed Redis directly via miniredis.
+	mr.Set("quiz:hints:sess-1:q-1", "3")
+	n, err := s.GetHintIndex(context.Background(), "sess-1", "q-1")
+	if err != nil {
+		t.Fatalf("GetHintIndex: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3, got %d", n)
+	}
+}
+
+// ── RecordAnswer — commit error ───────────────────────────────────────────────
+
+// TestRecordAnswer_CommitError_Propagated covers the Commit failure path in
+// RecordAnswer (the quiz session answer transaction).
+func TestRecordAnswer_CommitError_Propagated(t *testing.T) {
+	commitErr := errors.New("commit quiz answer failed")
+	tx := &txWithRowQueue{
+		mockTx: &mockTx{commitErr: commitErr},
+		rows:   []pgx.Row{quizSessionScanRow()},
+	}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	_, err := s.RecordAnswer(context.Background(), "sess-1", "user-1", "q-1", "A", true, 0, 10, nil)
+	if !errors.Is(err, commitErr) {
+		t.Errorf("expected commit error, got %v", err)
+	}
+}

--- a/services/gaming-service/internal/store/flashcard_coverage_test.go
+++ b/services/gaming-service/internal/store/flashcard_coverage_test.go
@@ -1,0 +1,184 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/teacherslounge/gaming-service/internal/model"
+)
+
+func flashcardScanRow() pgx.Row {
+	now := time.Now()
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "card-1"
+		*(dest[1].(*string)) = "user-1"
+		*(dest[2].(**string)) = nil
+		*(dest[3].(**string)) = nil
+		*(dest[4].(*string)) = "What is H2O?"
+		*(dest[5].(*string)) = "Water"
+		*(dest[6].(*string)) = "manual"
+		*(dest[7].(**string)) = nil
+		*(dest[8].(**string)) = nil
+		*(dest[9].(*float64)) = 2.5
+		*(dest[10].(*int)) = 1
+		*(dest[11].(*int)) = 0
+		*(dest[12].(*time.Time)) = now.Add(24 * time.Hour)
+		*(dest[13].(**time.Time)) = nil
+		*(dest[14].(*time.Time)) = now
+		return nil
+	}}
+}
+
+type flashcardRowsStub struct {
+	count int
+	pos   int
+}
+
+func (r *flashcardRowsStub) Next() bool { r.pos++; return r.pos-1 < r.count }
+func (r *flashcardRowsStub) Err() error { return nil }
+func (r *flashcardRowsStub) Close()     {}
+func (r *flashcardRowsStub) CommandTag() pgconn.CommandTag               { return pgconn.CommandTag{} }
+func (r *flashcardRowsStub) Conn() *pgx.Conn                             { return nil }
+func (r *flashcardRowsStub) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *flashcardRowsStub) Values() ([]any, error)                      { return nil, nil }
+func (r *flashcardRowsStub) RawValues() [][]byte                         { return nil }
+func (r *flashcardRowsStub) Scan(dest ...any) error {
+	now := time.Now()
+	*(dest[0].(*string)) = "card-1"
+	*(dest[1].(*string)) = "user-1"
+	*(dest[2].(**string)) = nil
+	*(dest[3].(**string)) = nil
+	*(dest[4].(*string)) = "Q"
+	*(dest[5].(*string)) = "A"
+	*(dest[6].(*string)) = "quiz"
+	*(dest[7].(**string)) = nil
+	*(dest[8].(**string)) = nil
+	*(dest[9].(*float64)) = 2.5
+	*(dest[10].(*int)) = 1
+	*(dest[11].(*int)) = 0
+	*(dest[12].(*time.Time)) = now
+	*(dest[13].(**time.Time)) = nil
+	*(dest[14].(*time.Time)) = now
+	return nil
+}
+
+type flashcardQueryDB struct {
+	qrows    pgx.Rows
+	queryErr error
+	qrow     pgx.Row
+}
+
+func (d *flashcardQueryDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if d.qrow != nil {
+		return d.qrow
+	}
+	return errFuncRow(pgx.ErrNoRows)
+}
+func (d *flashcardQueryDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return d.qrows, d.queryErr
+}
+func (d *flashcardQueryDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (d *flashcardQueryDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+func TestCreateFlashcard_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{flashcardScanRow()}})
+	got, err := s.CreateFlashcard(context.Background(), &model.Flashcard{UserID: "user-1", Front: "Q", Back: "A", Source: "manual"})
+	if err != nil || got.Front != "What is H2O?" {
+		t.Errorf("CreateFlashcard: err=%v front=%q", err, got.Front)
+	}
+}
+
+func TestCreateFlashcard_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("insert failed")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, err := s.CreateFlashcard(context.Background(), &model.Flashcard{UserID: "u"}); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestGetFlashcard_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{qrow: flashcardScanRow()})
+	got, err := s.GetFlashcard(context.Background(), "card-1")
+	if err != nil || got == nil || got.ID != "card-1" {
+		t.Errorf("GetFlashcard: err=%v got=%v", err, got)
+	}
+}
+
+func TestGetFlashcard_NotFound_ReturnsNil(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{})
+	got, err := s.GetFlashcard(context.Background(), "missing")
+	if err != nil || got != nil {
+		t.Errorf("expected nil,nil; got err=%v card=%v", err, got)
+	}
+}
+
+func TestListFlashcards_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{qrows: &flashcardRowsStub{count: 2}})
+	cards, err := s.ListFlashcards(context.Background(), "user-1")
+	if err != nil || len(cards) != 2 {
+		t.Errorf("ListFlashcards: err=%v len=%d", err, len(cards))
+	}
+}
+
+func TestListFlashcards_QueryError_Propagated(t *testing.T) {
+	dbErr := errors.New("query failed")
+	s := newMasteryStore(t, &flashcardQueryDB{queryErr: dbErr})
+	if _, err := s.ListFlashcards(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestDueFlashcards_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{qrows: &flashcardRowsStub{count: 1}})
+	cards, err := s.DueFlashcards(context.Background(), "user-1")
+	if err != nil || len(cards) != 1 {
+		t.Errorf("DueFlashcards: err=%v len=%d", err, len(cards))
+	}
+}
+
+func TestDueFlashcards_QueryError_Propagated(t *testing.T) {
+	dbErr := errors.New("due failed")
+	s := newMasteryStore(t, &flashcardQueryDB{queryErr: dbErr})
+	if _, err := s.DueFlashcards(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestFlashcardsForSession_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{qrows: &flashcardRowsStub{count: 3}})
+	cards, err := s.FlashcardsForSession(context.Background(), "session-1")
+	if err != nil || len(cards) != 3 {
+		t.Errorf("FlashcardsForSession: err=%v len=%d", err, len(cards))
+	}
+}
+
+func TestAllFlashcardsForExport_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &flashcardQueryDB{qrows: &flashcardRowsStub{count: 5}})
+	cards, err := s.AllFlashcardsForExport(context.Background(), "user-1")
+	if err != nil || len(cards) != 5 {
+		t.Errorf("AllFlashcardsForExport: err=%v len=%d", err, len(cards))
+	}
+}
+
+func TestReviewFlashcard_BeginError_Propagated(t *testing.T) {
+	beginErr := errors.New("pool exhausted")
+	s := newMasteryStore(t, &txDB{txErr: beginErr})
+	if _, err := s.ReviewFlashcard(context.Background(), "c", "u", 4); !errors.Is(err, beginErr) {
+		t.Errorf("expected begin error, got %v", err)
+	}
+}
+
+func TestReviewFlashcard_SelectError_Propagated(t *testing.T) {
+	selectErr := errors.New("lock timeout")
+	tx := &txWithQueryRow{mockTx: &mockTx{}, queryRow: errFuncRow(selectErr)}
+	s := newMasteryStore(t, &txDB{tx: tx})
+	if _, err := s.ReviewFlashcard(context.Background(), "c", "u", 4); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/services/gaming-service/internal/store/gap_coverage_test.go
+++ b/services/gaming-service/internal/store/gap_coverage_test.go
@@ -108,7 +108,7 @@ func TestDeleteBattleSession_RedisError_Propagated(t *testing.T) {
 // TestStreakCheckin_ResetPath_GapExceedsWindow verifies that when the stored
 // last_ts is more than 24 hours ago, the streak resets to 1 with reset=true.
 func TestStreakCheckin_ResetPath_GapExceedsWindow(t *testing.T) {
-	s, mr := newStoreWithRedis(t, &rowQueueDB{rows: []pgx.Row{&intRow{value: 1}}})
+	s, mr := newStoreWithRedis(t, &rowQueueDB{rows: []pgx.Row{&battleIntRow{value: 1}}})
 
 	// Seed Redis with a last_ts that is 26 hours in the past.
 	oldTS := time.Now().Add(-26 * time.Hour).Unix()

--- a/services/gaming-service/internal/store/gap_coverage_test.go
+++ b/services/gaming-service/internal/store/gap_coverage_test.go
@@ -1,0 +1,233 @@
+package store_test
+
+// Additional coverage tests to close the gap to ≥90% total coverage.
+// Focuses on: scanAssessmentSession with results, battle Redis errors,
+// GetFlashcard non-ErrNoRows error, StreakCheckin reset path.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ── scanAssessmentSession — results JSON path ─────────────────────────────────
+
+// assessmentSessionWithResultsScan returns a row where resultsRaw is a valid
+// JSON blob, exercising the json.Unmarshal branch in scanAssessmentSession.
+func assessmentSessionWithResultsScan() pgx.Row {
+	now := time.Now()
+	// Use a simple map as results placeholder.
+	resultsJSON, _ := json.Marshal(map[string]float64{"visual": 0.5, "verbal": -0.3})
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string))   = "asess-2"
+		*(dest[1].(*string))   = "user-2"
+		*(dest[2].(*string))   = "completed"
+		*(dest[3].(*int))      = 4
+		*(dest[4].(*int))      = 4
+		*(dest[5].(*int))      = 100
+		*(dest[6].(*[]byte))   = resultsJSON
+		*(dest[7].(*time.Time)) = now
+		*(dest[8].(**time.Time)) = nil
+		return nil
+	}}
+}
+
+// TestGetAssessmentSession_WithResults_UnmarshalsOK verifies that a completed
+// session row with a non-null results blob is correctly unmarshalled.
+func TestGetAssessmentSession_WithResults_UnmarshalsOK(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{assessmentSessionWithResultsScan()}}
+	s := newMasteryStore(t, db)
+	sess, err := s.GetAssessmentSession(context.Background(), "asess-2")
+	if err != nil {
+		t.Fatalf("GetAssessmentSession: %v", err)
+	}
+	if sess.ID != "asess-2" {
+		t.Errorf("ID: got %q, want asess-2", sess.ID)
+	}
+}
+
+// ── GetFlashcard — non-ErrNoRows error ───────────────────────────────────────
+
+// TestGetFlashcard_ScanError_Propagated verifies that scan errors other than
+// ErrNoRows are returned as errors (not silently swallowed).
+func TestGetFlashcard_ScanError_Propagated(t *testing.T) {
+	scanErr := errors.New("column type mismatch")
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(scanErr)}}
+	s := newMasteryStore(t, db)
+	_, err := s.GetFlashcard(context.Background(), "card-1")
+	if !errors.Is(err, scanErr) {
+		t.Errorf("expected scan error, got %v", err)
+	}
+}
+
+// ── Battle Redis error paths ──────────────────────────────────────────────────
+
+// TestSaveBattleSession_RedisError_Propagated verifies that a Redis Set failure
+// is wrapped and returned.
+func TestSaveBattleSession_RedisError_Propagated(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &execDB{})
+	mr.Close() // force connection failure
+	sess := battleSession("s-err")
+	sess.ExpiresAt = time.Now().Add(60 * time.Second)
+	err := s.SaveBattleSession(context.Background(), sess)
+	if err == nil {
+		t.Fatal("expected Redis error from SaveBattleSession, got nil")
+	}
+}
+
+// TestGetBattleSession_RedisError_Propagated verifies that a non-nil Redis
+// error (not redis.Nil) from Get is wrapped and returned.
+func TestGetBattleSession_RedisError_Propagated(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &execDB{})
+	mr.Close()
+	_, err := s.GetBattleSession(context.Background(), "s-err")
+	if err == nil {
+		t.Fatal("expected Redis error from GetBattleSession, got nil")
+	}
+}
+
+// TestDeleteBattleSession_RedisError_Propagated verifies that a Redis Del
+// failure is wrapped and returned.
+func TestDeleteBattleSession_RedisError_Propagated(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &execDB{})
+	mr.Close()
+	err := s.DeleteBattleSession(context.Background(), "s-err")
+	if err == nil {
+		t.Fatal("expected Redis error from DeleteBattleSession, got nil")
+	}
+}
+
+// ── StreakCheckin — reset path ────────────────────────────────────────────────
+
+// TestStreakCheckin_ResetPath_GapExceedsWindow verifies that when the stored
+// last_ts is more than 24 hours ago, the streak resets to 1 with reset=true.
+func TestStreakCheckin_ResetPath_GapExceedsWindow(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &rowQueueDB{rows: []pgx.Row{&intRow{value: 1}}})
+
+	// Seed Redis with a last_ts that is 26 hours in the past.
+	oldTS := time.Now().Add(-26 * time.Hour).Unix()
+	mr.HSet("streak:user-reset", "count", "5", "last_ts", fmt.Sprintf("%d", oldTS))
+
+	current, _, reset, err := s.StreakCheckin(context.Background(), "user-reset")
+	if err != nil {
+		t.Fatalf("StreakCheckin: %v", err)
+	}
+	if !reset {
+		t.Error("expected reset=true for gap > 24h")
+	}
+	if current != 1 {
+		t.Errorf("current: got %d, want 1 after reset", current)
+	}
+}
+
+// ── FlashcardsForSession / AllFlashcardsForExport — query error paths ─────────
+
+// TestFlashcardsForSession_QueryError_Propagated verifies db.Query failures surface.
+func TestFlashcardsForSession_QueryError_Propagated(t *testing.T) {
+	queryErr := errors.New("session query failed")
+	db := &flashcardQueryDB{queryErr: queryErr}
+	s := newMasteryStore(t, db)
+	_, err := s.FlashcardsForSession(context.Background(), "sess-1")
+	if !errors.Is(err, queryErr) {
+		t.Errorf("expected query error, got %v", err)
+	}
+}
+
+// TestAllFlashcardsForExport_QueryError_Propagated verifies db.Query failures surface.
+func TestAllFlashcardsForExport_QueryError_Propagated(t *testing.T) {
+	queryErr := errors.New("export query failed")
+	db := &flashcardQueryDB{queryErr: queryErr}
+	s := newMasteryStore(t, db)
+	_, err := s.AllFlashcardsForExport(context.Background(), "user-1")
+	if !errors.Is(err, queryErr) {
+		t.Errorf("expected query error, got %v", err)
+	}
+}
+
+// ── LeaderboardUpdateCourse — Redis error path ────────────────────────────────
+
+// TestLeaderboardUpdateCourse_RedisError_Propagated verifies that a ZAdd failure
+// is wrapped and returned.
+func TestLeaderboardUpdateCourse_RedisError_Propagated(t *testing.T) {
+	s, mr := newStoreWithRedis(t, &execDB{})
+	mr.Close()
+	err := s.LeaderboardUpdateCourse(context.Background(), "user-1", "course-1", 50)
+	if err == nil {
+		t.Fatal("expected Redis error from LeaderboardUpdateCourse, got nil")
+	}
+}
+
+// ── scanQuestion — options unmarshal error ────────────────────────────────────
+
+// questionWithBadOptionsRow returns a scan row where optionsRaw is malformed JSON,
+// triggering the json.Unmarshal error path in scanQuestion.
+func questionWithBadOptionsRow() pgx.Row {
+	courseID := "course-1"
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string))  = "q-bad"
+		*(dest[1].(**string)) = &courseID
+		*(dest[2].(*string))  = "math"
+		*(dest[3].(*int))     = 1
+		*(dest[4].(*string))  = "Bad question"
+		*(dest[5].(*[]byte))  = []byte("not valid json") // bad options
+		*(dest[6].(*string))  = "A"
+		*(dest[7].(*[]byte))  = []byte(`["hint"]`)
+		*(dest[8].(*string))  = "explanation"
+		*(dest[9].(*int))     = 5
+		return nil
+	}}
+}
+
+// TestGetQuestion_BadOptionsJSON_ReturnsError verifies that malformed options JSON
+// is detected and returned as an error rather than silently corrupting data.
+func TestGetQuestion_BadOptionsJSON_ReturnsError(t *testing.T) {
+	db := &quizQueryDB{qrow: questionWithBadOptionsRow()}
+	s := newMasteryStore(t, db)
+	_, err := s.GetQuestion(context.Background(), "q-bad")
+	if err == nil {
+		t.Fatal("expected unmarshal error for bad options JSON, got nil")
+	}
+}
+
+// ── collectFlashcards — scan error path ───────────────────────────────────────
+
+// flashcardErrRows implements pgx.Rows for a single row whose Scan always errors.
+type flashcardErrRows struct {
+	used    bool
+	scanErr error
+}
+
+func (r *flashcardErrRows) Close()                                         {}
+func (r *flashcardErrRows) Err() error                                     { return nil }
+func (r *flashcardErrRows) CommandTag() pgconn.CommandTag                  { return pgconn.CommandTag{} }
+func (r *flashcardErrRows) FieldDescriptions() []pgconn.FieldDescription   { return nil }
+func (r *flashcardErrRows) Conn() *pgx.Conn                                { return nil }
+func (r *flashcardErrRows) Next() bool {
+	if r.used {
+		return false
+	}
+	r.used = true
+	return true
+}
+func (r *flashcardErrRows) Scan(_ ...any) error    { return r.scanErr }
+func (r *flashcardErrRows) Values() ([]any, error) { return nil, nil }
+func (r *flashcardErrRows) RawValues() [][]byte    { return nil }
+
+// TestFlashcardsForSession_ScanError_Propagated verifies that a scan error
+// inside collectFlashcards is surfaced rather than silently dropped.
+func TestFlashcardsForSession_ScanError_Propagated(t *testing.T) {
+	scanErr := errors.New("flashcard scan failed")
+	rows := &flashcardErrRows{scanErr: scanErr}
+	db := &flashcardQueryDB{qrows: rows}
+	s := newMasteryStore(t, db)
+	_, err := s.FlashcardsForSession(context.Background(), "sess-1")
+	if err == nil {
+		t.Fatal("expected scan error from FlashcardsForSession, got nil")
+	}
+}

--- a/services/gaming-service/internal/store/leaderboard_coverage_test.go
+++ b/services/gaming-service/internal/store/leaderboard_coverage_test.go
@@ -1,0 +1,237 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/teacherslounge/gaming-service/internal/model"
+	"github.com/teacherslounge/gaming-service/internal/rival"
+	"github.com/teacherslounge/gaming-service/internal/store"
+)
+
+func newLBStore(t *testing.T) *store.Store {
+	t.Helper()
+	return newMasteryStore(t, &txDB{})
+}
+
+func addXP(t *testing.T, s *store.Store, userID string, xp int64) {
+	t.Helper()
+	if err := s.LeaderboardUpdate(context.Background(), userID, xp); err != nil {
+		t.Fatalf("LeaderboardUpdate(%q, %d): %v", userID, xp, err)
+	}
+}
+
+func TestLeaderboardUpdateCourse_AppearsInCourseBoard(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	if err := s.LeaderboardUpdateCourse(ctx, "alice", "course-go-101", 500); err != nil {
+		t.Fatalf("LeaderboardUpdateCourse: %v", err)
+	}
+	entries, _, err := s.LeaderboardGetCourse(ctx, "alice", "course-go-101")
+	if err != nil {
+		t.Fatalf("LeaderboardGetCourse: %v", err)
+	}
+	if len(entries) != 1 || entries[0].UserID != "alice" {
+		t.Errorf("expected alice in course board, got %v", entries)
+	}
+}
+
+func TestLeaderboardUpdateCourse_IsolatedFromGlobal(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	if err := s.LeaderboardUpdateCourse(ctx, "bob", "course-python-201", 1000); err != nil {
+		t.Fatalf("LeaderboardUpdateCourse: %v", err)
+	}
+	global, _, err := s.LeaderboardTop10(ctx, "bob")
+	if err != nil {
+		t.Fatalf("LeaderboardTop10: %v", err)
+	}
+	for _, e := range global {
+		if e.UserID == "bob" {
+			t.Errorf("bob should not appear in global board from course update")
+		}
+	}
+}
+
+func TestLeaderboardGetPeriod_WeeklyReturnsCurrentWeek(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "alice", 300)
+	addXP(t, s, "bob", 200)
+	entries, _, err := s.LeaderboardGetPeriod(ctx, "alice", model.PeriodWeekly)
+	if err != nil {
+		t.Fatalf("LeaderboardGetPeriod weekly: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected entries in weekly board")
+	}
+	if entries[0].UserID != "alice" {
+		t.Errorf("rank 1: want alice, got %s", entries[0].UserID)
+	}
+}
+
+func TestLeaderboardGetPeriod_MonthlyReturnsCurrentMonth(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "carol", 800)
+	addXP(t, s, "dave", 400)
+	entries, _, err := s.LeaderboardGetPeriod(ctx, "carol", model.PeriodMonthly)
+	if err != nil {
+		t.Fatalf("LeaderboardGetPeriod monthly: %v", err)
+	}
+	if len(entries) == 0 || entries[0].UserID != "carol" {
+		t.Errorf("want carol as rank 1, got %v", entries)
+	}
+}
+
+func TestLeaderboardGetPeriod_AllTimeFallsBackToGlobal(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "eve", 600)
+	entries, _, err := s.LeaderboardGetPeriod(ctx, "eve", "all_time")
+	if err != nil {
+		t.Fatalf("LeaderboardGetPeriod all_time: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.UserID == "eve" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("eve not found in all_time leaderboard")
+	}
+}
+
+func TestLeaderboardGetPeriod_UserRankIncluded(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "alice", 500)
+	addXP(t, s, "bob", 300)
+	_, userRank, err := s.LeaderboardGetPeriod(ctx, "bob", model.PeriodWeekly)
+	if err != nil {
+		t.Fatalf("LeaderboardGetPeriod: %v", err)
+	}
+	if userRank == nil || userRank.Rank != 2 {
+		t.Errorf("bob rank: want 2, got %v", userRank)
+	}
+}
+
+func TestLeaderboardGetCourse_RankedByXP(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	const course = "course-chem-101"
+	for _, tc := range []struct{ id string; xp float64 }{
+		{"alice", 700}, {"bob", 400}, {"carol", 900},
+	} {
+		if err := s.LeaderboardUpdateCourse(ctx, tc.id, course, int64(tc.xp)); err != nil {
+			t.Fatalf("course update %s: %v", tc.id, err)
+		}
+	}
+	entries, _, err := s.LeaderboardGetCourse(ctx, "alice", course)
+	if err != nil {
+		t.Fatalf("LeaderboardGetCourse: %v", err)
+	}
+	if len(entries) < 3 || entries[0].UserID != "carol" {
+		t.Errorf("expected carol at rank 1, got %v", entries)
+	}
+}
+
+func TestLeaderboardGetCourse_EmptyBoard(t *testing.T) {
+	s := newLBStore(t)
+	entries, _, err := s.LeaderboardGetCourse(context.Background(), "x", "course-empty")
+	if err != nil {
+		t.Fatalf("LeaderboardGetCourse: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty board, got %d", len(entries))
+	}
+}
+
+func TestLeaderboardGetFriends_RankedByGlobalXP(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "alice", 800)
+	addXP(t, s, "bob", 600)
+	addXP(t, s, "carol", 400)
+	entries, userRank, err := s.LeaderboardGetFriends(ctx, "alice", []string{"bob", "carol"})
+	if err != nil {
+		t.Fatalf("LeaderboardGetFriends: %v", err)
+	}
+	if len(entries) != 3 || entries[0].UserID != "alice" {
+		t.Errorf("want alice at rank 1, got %v", entries)
+	}
+	if userRank == nil || userRank.Rank != 1 {
+		t.Errorf("alice rank: want 1, got %v", userRank)
+	}
+}
+
+func TestLeaderboardGetFriends_UnknownUser_ScoreZero(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "alice", 500)
+	entries, _, err := s.LeaderboardGetFriends(ctx, "alice", []string{"nobody"})
+	if err != nil {
+		t.Fatalf("LeaderboardGetFriends: %v", err)
+	}
+	for _, e := range entries {
+		if e.UserID == "nobody" && e.XP != 0 {
+			t.Errorf("unknown user XP: want 0, got %v", e.XP)
+		}
+	}
+}
+
+func TestLeaderboardGetFriends_NoFriends_CallerOnly(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	addXP(t, s, "solo", 300)
+	entries, userRank, err := s.LeaderboardGetFriends(ctx, "solo", nil)
+	if err != nil {
+		t.Fatalf("LeaderboardGetFriends: %v", err)
+	}
+	if len(entries) != 1 || entries[0].UserID != "solo" {
+		t.Errorf("want [solo], got %v", entries)
+	}
+	if userRank == nil || userRank.Rank != 1 {
+		t.Errorf("userRank: want rank 1, got %v", userRank)
+	}
+}
+
+func TestSeedRivals_EmptySlice_NoOp(t *testing.T) {
+	s := newLBStore(t)
+	if err := s.SeedRivals(context.Background(), nil); err != nil {
+		t.Fatalf("SeedRivals(nil): %v", err)
+	}
+}
+
+func TestSeedRivals_PreservesExistingScore(t *testing.T) {
+	s := newLBStore(t)
+	ctx := context.Background()
+	r := rival.Rival{ID: "rival:test-rival", BaseXP: 100, DailyGainMin: 5, DailyGainMax: 10}
+	if err := s.SeedRivals(ctx, []rival.Rival{r}); err != nil {
+		t.Fatalf("first SeedRivals: %v", err)
+	}
+	if err := s.LeaderboardUpdate(ctx, r.ID, 500); err != nil {
+		t.Fatalf("LeaderboardUpdate: %v", err)
+	}
+	if err := s.SeedRivals(ctx, []rival.Rival{r}); err != nil {
+		t.Fatalf("second SeedRivals: %v", err)
+	}
+	entries, _, err := s.LeaderboardTop10(ctx, "")
+	if err != nil {
+		t.Fatalf("LeaderboardTop10: %v", err)
+	}
+	for _, e := range entries {
+		if e.UserID == r.ID && e.XP != 500 {
+			t.Errorf("rival score: want 500, got %v", e.XP)
+		}
+	}
+}
+
+func TestTickRivals_EmptySlice_NoOp(t *testing.T) {
+	s := newLBStore(t)
+	if err := s.TickRivals(context.Background(), nil); err != nil {
+		t.Fatalf("TickRivals(nil): %v", err)
+	}
+}

--- a/services/gaming-service/internal/store/quiz_coverage_test.go
+++ b/services/gaming-service/internal/store/quiz_coverage_test.go
@@ -1,0 +1,335 @@
+package store_test
+
+// Tests for quiz.go — GetRandomQuestions, GetQuestion, CreateQuizSession,
+// GetQuizSession, AbandonQuizSession, GetHintIndex, IncrHintIndex, RecordAnswer.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/teacherslounge/gaming-service/internal/store"
+)
+
+// ── row/rows helpers ──────────────────────────────────────────────────────────
+
+// questionScanRow returns a funcRow that scans 10 fields for a Question.
+func questionScanRow() pgx.Row {
+	optJSON, _ := json.Marshal([]map[string]string{{"key": "A", "text": "yes"}, {"key": "B", "text": "no"}})
+	hintsJSON, _ := json.Marshal([]string{"hint1"})
+	courseID := "course-1"
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string))  = "q-1"
+		*(dest[1].(**string)) = &courseID
+		*(dest[2].(*string))  = "algebra"
+		*(dest[3].(*int))     = 2
+		*(dest[4].(*string))  = "What is 1+1?"
+		*(dest[5].(*[]byte))  = optJSON
+		*(dest[6].(*string))  = "A"
+		*(dest[7].(*[]byte))  = hintsJSON
+		*(dest[8].(*string))  = "Basic math"
+		*(dest[9].(*int))     = 10
+		return nil
+	}}
+}
+
+// quizSessionScanRow returns a funcRow that scans 12 fields for a QuizSession.
+func quizSessionScanRow() pgx.Row {
+	now := time.Now()
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string))    = "sess-1"
+		*(dest[1].(*string))    = "user-1"
+		*(dest[2].(**string))   = nil
+		*(dest[3].(**string))   = nil
+		*(dest[4].(*string))    = "in_progress"
+		*(dest[5].(*[]string))  = []string{"q-1", "q-2"}
+		*(dest[6].(*int))       = 0
+		*(dest[7].(*int))       = 2
+		*(dest[8].(*int))       = 0
+		*(dest[9].(*int))       = 0
+		*(dest[10].(*time.Time))  = now
+		*(dest[11].(**time.Time)) = nil
+		return nil
+	}}
+}
+
+// questionRowsStub implements pgx.Rows for a single question row.
+type questionRowsStub struct {
+	row    pgx.Row
+	used   bool
+	rowErr error
+}
+
+func (r *questionRowsStub) Close()                                          {}
+func (r *questionRowsStub) Err() error                                      { return r.rowErr }
+func (r *questionRowsStub) CommandTag() pgconn.CommandTag                   { return pgconn.CommandTag{} }
+func (r *questionRowsStub) FieldDescriptions() []pgconn.FieldDescription    { return nil }
+func (r *questionRowsStub) Next() bool {
+	if r.used {
+		return false
+	}
+	r.used = true
+	return true
+}
+func (r *questionRowsStub) Scan(dest ...any) error    { return r.row.Scan(dest...) }
+func (r *questionRowsStub) Values() ([]any, error)    { return nil, nil }
+func (r *questionRowsStub) RawValues() [][]byte       { return nil }
+func (r *questionRowsStub) Conn() *pgx.Conn           { return nil }
+
+// quizQueryDB routes calls to configurable stubs.
+type quizQueryDB struct {
+	qrows   pgx.Rows
+	qrow    pgx.Row
+	execErr error
+	tx      pgx.Tx
+	txErr   error
+}
+
+func (d *quizQueryDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if d.qrow != nil {
+		return d.qrow
+	}
+	return errFuncRow(errors.New("no qrow configured"))
+}
+func (d *quizQueryDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	if d.qrows != nil {
+		return d.qrows, nil
+	}
+	return nil, errors.New("query error")
+}
+func (d *quizQueryDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, d.execErr
+}
+func (d *quizQueryDB) Begin(_ context.Context) (pgx.Tx, error) {
+	if d.txErr != nil {
+		return nil, d.txErr
+	}
+	return d.tx, nil
+}
+
+// ── GetRandomQuestions ────────────────────────────────────────────────────────
+
+// TestGetRandomQuestions_HappyPath verifies a single question row is returned.
+func TestGetRandomQuestions_HappyPath(t *testing.T) {
+	stub := &questionRowsStub{row: questionScanRow()}
+	db := &quizQueryDB{qrows: stub}
+	s := newMasteryStore(t, db)
+	qs, err := s.GetRandomQuestions(context.Background(), "algebra", 1)
+	if err != nil {
+		t.Fatalf("GetRandomQuestions: %v", err)
+	}
+	if len(qs) != 1 {
+		t.Fatalf("expected 1 question, got %d", len(qs))
+	}
+	if qs[0].ID != "q-1" {
+		t.Errorf("ID: got %q, want q-1", qs[0].ID)
+	}
+}
+
+// TestGetRandomQuestions_QueryError_Propagated verifies DB errors are returned.
+func TestGetRandomQuestions_QueryError_Propagated(t *testing.T) {
+	db := &quizQueryDB{} // nil qrows → error path
+	s := newMasteryStore(t, db)
+	_, err := s.GetRandomQuestions(context.Background(), "algebra", 1)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ── GetQuestion ───────────────────────────────────────────────────────────────
+
+// TestGetQuestion_HappyPath verifies a question is returned by ID.
+func TestGetQuestion_HappyPath(t *testing.T) {
+	db := &quizQueryDB{qrow: questionScanRow()}
+	s := newMasteryStore(t, db)
+	q, err := s.GetQuestion(context.Background(), "q-1")
+	if err != nil {
+		t.Fatalf("GetQuestion: %v", err)
+	}
+	if q.ID != "q-1" {
+		t.Errorf("ID: got %q, want q-1", q.ID)
+	}
+	if q.XPReward != 10 {
+		t.Errorf("XPReward: got %d, want 10", q.XPReward)
+	}
+}
+
+// TestGetQuestion_NotFound_ReturnsError verifies scan errors are propagated.
+func TestGetQuestion_NotFound_ReturnsError(t *testing.T) {
+	db := &quizQueryDB{qrow: errFuncRow(pgx.ErrNoRows)}
+	s := newMasteryStore(t, db)
+	_, err := s.GetQuestion(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for missing question, got nil")
+	}
+}
+
+// ── CreateQuizSession ─────────────────────────────────────────────────────────
+
+// TestCreateQuizSession_HappyPath verifies a session row is inserted and returned.
+func TestCreateQuizSession_HappyPath(t *testing.T) {
+	db := &quizQueryDB{qrow: quizSessionScanRow()}
+	s := newMasteryStore(t, db)
+	sess, err := s.CreateQuizSession(context.Background(), "user-1", nil, nil, []string{"q-1", "q-2"})
+	if err != nil {
+		t.Fatalf("CreateQuizSession: %v", err)
+	}
+	if sess.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want user-1", sess.UserID)
+	}
+	if sess.TotalQuestions != 2 {
+		t.Errorf("TotalQuestions: got %d, want 2", sess.TotalQuestions)
+	}
+}
+
+// TestCreateQuizSession_DBError_Propagated verifies scan errors are returned.
+func TestCreateQuizSession_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("insert failed")
+	db := &quizQueryDB{qrow: errFuncRow(dbErr)}
+	s := newMasteryStore(t, db)
+	_, err := s.CreateQuizSession(context.Background(), "user-1", nil, nil, []string{"q-1"})
+	if !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped DB error, got %v", err)
+	}
+}
+
+// ── GetQuizSession ────────────────────────────────────────────────────────────
+
+// TestGetQuizSession_HappyPath verifies a session is returned by ID.
+func TestGetQuizSession_HappyPath(t *testing.T) {
+	db := &quizQueryDB{qrow: quizSessionScanRow()}
+	s := newMasteryStore(t, db)
+	sess, err := s.GetQuizSession(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("GetQuizSession: %v", err)
+	}
+	if sess.ID != "sess-1" {
+		t.Errorf("ID: got %q, want sess-1", sess.ID)
+	}
+}
+
+// TestGetQuizSession_NotFound_ReturnsError verifies ErrNoRows is returned.
+func TestGetQuizSession_NotFound_ReturnsError(t *testing.T) {
+	db := &quizQueryDB{qrow: errFuncRow(pgx.ErrNoRows)}
+	s := newMasteryStore(t, db)
+	_, err := s.GetQuizSession(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for missing session, got nil")
+	}
+}
+
+// ── AbandonQuizSession ────────────────────────────────────────────────────────
+
+// TestAbandonQuizSession_HappyPath verifies Exec is called with no error.
+func TestAbandonQuizSession_HappyPath(t *testing.T) {
+	db := &quizQueryDB{}
+	s := newMasteryStore(t, db)
+	if err := s.AbandonQuizSession(context.Background(), "sess-1"); err != nil {
+		t.Errorf("AbandonQuizSession: unexpected error: %v", err)
+	}
+}
+
+// TestAbandonQuizSession_DBError_Propagated verifies Exec errors are returned.
+func TestAbandonQuizSession_DBError_Propagated(t *testing.T) {
+	execErr := errors.New("update failed")
+	db := &quizQueryDB{execErr: execErr}
+	s := newMasteryStore(t, db)
+	err := s.AbandonQuizSession(context.Background(), "sess-1")
+	if !errors.Is(err, execErr) {
+		t.Errorf("expected DB error, got %v", err)
+	}
+}
+
+// ── GetHintIndex ──────────────────────────────────────────────────────────────
+
+// TestGetHintIndex_MissingKey_ReturnsZero verifies Redis Nil returns 0, nil.
+func TestGetHintIndex_MissingKey_ReturnsZero(t *testing.T) {
+	s := newMasteryStore(t, &execDB{}) // miniredis with empty state
+	n, err := s.GetHintIndex(context.Background(), "sess-1", "q-1")
+	if err != nil {
+		t.Fatalf("GetHintIndex: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0, got %d", n)
+	}
+}
+
+// ── IncrHintIndex ─────────────────────────────────────────────────────────────
+
+// TestIncrHintIndex_HappyPath verifies gem deduction and counter increment.
+func TestIncrHintIndex_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&intRow{value: 4}}}
+	s := newMasteryStore(t, db)
+	idx, gems, err := s.IncrHintIndex(context.Background(), "sess-1", "q-1", "user-1")
+	if err != nil {
+		t.Fatalf("IncrHintIndex: %v", err)
+	}
+	if gems != 4 {
+		t.Errorf("gems: got %d, want 4", gems)
+	}
+	if idx != 0 {
+		t.Errorf("idx: got %d, want 0", idx)
+	}
+}
+
+// TestIncrHintIndex_NoGems_ReturnsErrNoGems verifies ErrNoRows → ErrNoGems.
+func TestIncrHintIndex_NoGems_ReturnsErrNoGems(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(pgx.ErrNoRows)}}
+	s := newMasteryStore(t, db)
+	_, _, err := s.IncrHintIndex(context.Background(), "sess-1", "q-1", "user-1")
+	if !errors.Is(err, store.ErrNoGems) {
+		t.Errorf("expected ErrNoGems, got %v", err)
+	}
+}
+
+// TestIncrHintIndex_DBError_Propagated verifies other DB errors are wrapped.
+func TestIncrHintIndex_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("deduct gem failed")
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}}
+	s := newMasteryStore(t, db)
+	_, _, err := s.IncrHintIndex(context.Background(), "sess-1", "q-1", "user-1")
+	if !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped DB error, got %v", err)
+	}
+}
+
+// ── RecordAnswer ──────────────────────────────────────────────────────────────
+
+// TestRecordAnswer_BeginError_Propagated verifies Begin failures surface.
+func TestRecordAnswer_BeginError_Propagated(t *testing.T) {
+	beginErr := errors.New("pool exhausted")
+	db := &txDB{txErr: beginErr}
+	s := newMasteryStore(t, db)
+	_, err := s.RecordAnswer(context.Background(), "sess-1", "user-1", "q-1", "A", true, 0, 10, nil)
+	if !errors.Is(err, beginErr) {
+		t.Errorf("expected begin error, got %v", err)
+	}
+}
+
+// TestRecordAnswer_ExecError_Propagated verifies INSERT answer failures surface.
+func TestRecordAnswer_ExecError_Propagated(t *testing.T) {
+	execErr := errors.New("insert answer failed")
+	tx := &mockTx{execErr: execErr}
+	db := &txDB{tx: tx}
+	s := newMasteryStore(t, db)
+	_, err := s.RecordAnswer(context.Background(), "sess-1", "user-1", "q-1", "A", true, 0, 10, nil)
+	if err == nil {
+		t.Fatal("expected error from Exec failure, got nil")
+	}
+}
+
+// TestRecordAnswer_SelectError_Propagated verifies UPDATE session scan failures surface.
+func TestRecordAnswer_SelectError_Propagated(t *testing.T) {
+	selectErr := errors.New("update session failed")
+	tx := &txWithQueryRow{mockTx: &mockTx{}, queryRow: errFuncRow(selectErr)}
+	db := &txDB{tx: tx}
+	s := newMasteryStore(t, db)
+	_, err := s.RecordAnswer(context.Background(), "sess-1", "user-1", "q-1", "A", true, 0, 10, nil)
+	if err == nil {
+		t.Fatal("expected error from SELECT failure, got nil")
+	}
+}

--- a/services/gaming-service/internal/store/quiz_coverage_test.go
+++ b/services/gaming-service/internal/store/quiz_coverage_test.go
@@ -262,7 +262,7 @@ func TestGetHintIndex_MissingKey_ReturnsZero(t *testing.T) {
 
 // TestIncrHintIndex_HappyPath verifies gem deduction and counter increment.
 func TestIncrHintIndex_HappyPath(t *testing.T) {
-	db := &rowQueueDB{rows: []pgx.Row{&intRow{value: 4}}}
+	db := &rowQueueDB{rows: []pgx.Row{&battleIntRow{value: 4}}}
 	s := newMasteryStore(t, db)
 	idx, gems, err := s.IncrHintIndex(context.Background(), "sess-1", "q-1", "user-1")
 	if err != nil {

--- a/services/gaming-service/internal/store/store_coverage_test.go
+++ b/services/gaming-service/internal/store/store_coverage_test.go
@@ -1,0 +1,571 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ── funcRow ───────────────────────────────────────────────────────────────────
+
+type funcRow struct {
+	fn func(dest ...any) error
+}
+
+func (r *funcRow) Scan(dest ...any) error { return r.fn(dest...) }
+
+func errFuncRow(err error) pgx.Row { return &funcRow{fn: func(_ ...any) error { return err }} }
+
+// ── rowQueueDB ────────────────────────────────────────────────────────────────
+
+type rowQueueDB struct {
+	rows    []pgx.Row
+	idx     int
+	execErr error
+}
+
+func (d *rowQueueDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if d.idx >= len(d.rows) {
+		return errFuncRow(errors.New("rowQueueDB: no more rows"))
+	}
+	r := d.rows[d.idx]
+	d.idx++
+	return r
+}
+func (d *rowQueueDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
+func (d *rowQueueDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, d.execErr
+}
+func (d *rowQueueDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+// ── stringRows ────────────────────────────────────────────────────────────────
+
+type stringRows struct {
+	data []string
+	pos  int
+	err  error
+}
+
+func (r *stringRows) Next() bool                                  { r.pos++; return r.pos-1 < len(r.data) }
+func (r *stringRows) Err() error                                  { return r.err }
+func (r *stringRows) Close()                                      {}
+func (r *stringRows) CommandTag() pgconn.CommandTag               { return pgconn.CommandTag{} }
+func (r *stringRows) Conn() *pgx.Conn                             { return nil }
+func (r *stringRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *stringRows) Values() ([]any, error)                      { return nil, nil }
+func (r *stringRows) RawValues() [][]byte                         { return nil }
+func (r *stringRows) Scan(dest ...any) error {
+	if r.pos == 0 || r.pos-1 >= len(r.data) {
+		return errors.New("stringRows: no current row")
+	}
+	*(dest[0].(*string)) = r.data[r.pos-1]
+	return nil
+}
+
+// ── queryDB ───────────────────────────────────────────────────────────────────
+
+type queryDB struct {
+	qrows    pgx.Rows
+	queryErr error
+}
+
+func (d *queryDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row     { return nil }
+func (d *queryDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return d.qrows, d.queryErr
+}
+func (d *queryDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (d *queryDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+// ── execDB ────────────────────────────────────────────────────────────────────
+
+type execDB struct {
+	execCalls int
+	execErr   error
+	row       pgx.Row
+}
+
+func (d *execDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return d.row }
+func (d *execDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) { return nil, nil }
+func (d *execDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	d.execCalls++
+	return pgconn.CommandTag{}, d.execErr
+}
+func (d *execDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+// ── achievementRows ───────────────────────────────────────────────────────────
+
+type achievementRows struct {
+	data [][]any
+	pos  int
+}
+
+func (r *achievementRows) Next() bool { r.pos++; return r.pos-1 < len(r.data) }
+func (r *achievementRows) Err() error { return nil }
+func (r *achievementRows) Close()     {}
+func (r *achievementRows) CommandTag() pgconn.CommandTag               { return pgconn.CommandTag{} }
+func (r *achievementRows) Conn() *pgx.Conn                             { return nil }
+func (r *achievementRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *achievementRows) Values() ([]any, error)                      { return nil, nil }
+func (r *achievementRows) RawValues() [][]byte                         { return nil }
+func (r *achievementRows) Scan(dest ...any) error {
+	row := r.data[r.pos-1]
+	*(dest[0].(*string)) = row[0].(string)
+	*(dest[1].(*string)) = row[1].(string)
+	*(dest[2].(*string)) = row[2].(string)
+	*(dest[3].(*string)) = row[3].(string)
+	*(dest[4].(*time.Time)) = row[4].(time.Time)
+	return nil
+}
+
+type achievementQueryDB struct {
+	rows     pgx.Rows
+	queryErr error
+}
+
+func (d *achievementQueryDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return errFuncRow(pgx.ErrNoRows)
+}
+func (d *achievementQueryDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return d.rows, d.queryErr
+}
+func (d *achievementQueryDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (d *achievementQueryDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+type grantAchievementDB struct {
+	mainRow   pgx.Row
+	fetchRow  pgx.Row
+	callCount int
+}
+
+func (d *grantAchievementDB) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	d.callCount++
+	if d.callCount == 1 {
+		return d.mainRow
+	}
+	return d.fetchRow
+}
+func (d *grantAchievementDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+func (d *grantAchievementDB) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (d *grantAchievementDB) Begin(_ context.Context) (pgx.Tx, error) { return nil, nil }
+
+func achievementScanRow() pgx.Row {
+	now := time.Now()
+	return &funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "ach-1"
+		*(dest[1].(*string)) = "user-1"
+		*(dest[2].(*string)) = "first_win"
+		*(dest[3].(*string)) = "First Victory"
+		*(dest[4].(*time.Time)) = now
+		return nil
+	}}
+}
+
+// ── GetProfile ────────────────────────────────────────────────────────────────
+
+func TestGetProfile_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "user-1"
+		*(dest[1].(*int)) = 5
+		*(dest[2].(*int64)) = 1500
+		*(dest[3].(*int)) = 3
+		*(dest[4].(*int)) = 7
+		*(dest[5].(*int)) = 2
+		*(dest[6].(*int)) = 50
+		*(dest[7].(*[]byte)) = []byte(`{"shield":1}`)
+		*(dest[8].(**time.Time)) = nil
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	p, err := s.GetProfile(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if p.Level != 5 || p.XP != 1500 {
+		t.Errorf("Level=%d XP=%d; want 5 1500", p.Level, p.XP)
+	}
+}
+
+func TestGetProfile_NilPowerUps_DefaultsToEmpty(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "user-2"
+		*(dest[1].(*int)) = 1
+		*(dest[2].(*int64)) = 0
+		*(dest[3].(*int)) = 0
+		*(dest[4].(*int)) = 0
+		*(dest[5].(*int)) = 0
+		*(dest[6].(*int)) = 0
+		*(dest[7].(*[]byte)) = nil
+		*(dest[8].(**time.Time)) = nil
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	p, err := s.GetProfile(context.Background(), "user-2")
+	if err != nil {
+		t.Fatalf("GetProfile: %v", err)
+	}
+	if string(p.PowerUps) != "{}" {
+		t.Errorf("PowerUps: got %q, want {}", string(p.PowerUps))
+	}
+}
+
+func TestGetProfile_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("connection refused")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, err := s.GetProfile(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── UpsertXP ──────────────────────────────────────────────────────────────────
+
+func TestUpsertXP_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{})
+	if err := s.UpsertXP(context.Background(), "user-1", 2000, 6); err != nil {
+		t.Fatalf("UpsertXP: %v", err)
+	}
+}
+
+func TestUpsertXP_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("db down")
+	s := newMasteryStore(t, &rowQueueDB{execErr: dbErr})
+	if err := s.UpsertXP(context.Background(), "u", 100, 1); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── GetXPAndLevel ─────────────────────────────────────────────────────────────
+
+func TestGetXPAndLevel_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*int64)) = 800
+		*(dest[1].(*int)) = 4
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	xp, level, err := s.GetXPAndLevel(context.Background(), "u")
+	if err != nil {
+		t.Fatalf("GetXPAndLevel: %v", err)
+	}
+	if xp != 800 || level != 4 {
+		t.Errorf("got xp=%d level=%d; want 800 4", xp, level)
+	}
+}
+
+func TestGetXPAndLevel_NoRows_ReturnsDefaults(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(errors.New("any"))}})
+	xp, level, err := s.GetXPAndLevel(context.Background(), "fresh")
+	if err != nil {
+		t.Fatalf("GetXPAndLevel: %v", err)
+	}
+	if xp != 0 || level != 1 {
+		t.Errorf("defaults: xp=%d level=%d; want 0 1", xp, level)
+	}
+}
+
+// ── StreakCheckin ─────────────────────────────────────────────────────────────
+
+func TestStreakCheckin_FirstCheckin_StartStreak(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*int)) = 1
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	current, longest, reset, err := s.StreakCheckin(context.Background(), "user-streak")
+	if err != nil {
+		t.Fatalf("StreakCheckin: %v", err)
+	}
+	if current != 1 || longest != 1 || reset {
+		t.Errorf("got current=%d longest=%d reset=%v; want 1 1 false", current, longest, reset)
+	}
+}
+
+func TestStreakCheckin_ConsecutiveCheckin_IncrementsStreak(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{
+		&funcRow{fn: func(dest ...any) error { *(dest[0].(*int)) = 1; return nil }},
+		&funcRow{fn: func(dest ...any) error { *(dest[0].(*int)) = 2; return nil }},
+	}}
+	s := newMasteryStore(t, db)
+	ctx := context.Background()
+	if _, _, _, err := s.StreakCheckin(ctx, "user-cons"); err != nil {
+		t.Fatalf("first StreakCheckin: %v", err)
+	}
+	current, _, reset, err := s.StreakCheckin(ctx, "user-cons")
+	if err != nil {
+		t.Fatalf("second StreakCheckin: %v", err)
+	}
+	if current != 2 || reset {
+		t.Errorf("got current=%d reset=%v; want 2 false", current, reset)
+	}
+}
+
+func TestStreakCheckin_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("upsert failed")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, _, _, err := s.StreakCheckin(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── RandomQuote ───────────────────────────────────────────────────────────────
+
+func TestRandomQuote_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*int)) = 42
+		*(dest[1].(*string)) = "Live long and prosper."
+		*(dest[2].(*string)) = "Spock"
+		*(dest[3].(*string)) = "greeting"
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	q, err := s.RandomQuote(context.Background())
+	if err != nil {
+		t.Fatalf("RandomQuote: %v", err)
+	}
+	if q.Quote != "Live long and prosper." {
+		t.Errorf("Quote: got %q", q.Quote)
+	}
+}
+
+func TestRandomQuote_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("quote db down")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, err := s.RandomQuote(context.Background()); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── AwardQuestRewards ─────────────────────────────────────────────────────────
+
+func TestAwardQuestRewards_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{
+		&funcRow{fn: func(dest ...any) error {
+			*(dest[0].(*int64)) = 500
+			*(dest[1].(*int)) = 3
+			return nil
+		}},
+		&funcRow{fn: func(dest ...any) error {
+			*(dest[0].(*int)) = 65
+			return nil
+		}},
+	}}
+	s := newMasteryStore(t, db)
+	newXP, newLevel, _, newGems, err := s.AwardQuestRewards(context.Background(), "u", 100, 15)
+	if err != nil {
+		t.Fatalf("AwardQuestRewards: %v", err)
+	}
+	if newXP < 600 || newLevel < 1 || newGems != 65 {
+		t.Errorf("got xp=%d level=%d gems=%d", newXP, newLevel, newGems)
+	}
+}
+
+func TestAwardQuestRewards_UpsertError_Propagated(t *testing.T) {
+	dbErr := errors.New("upsert failed")
+	db := &rowQueueDB{rows: []pgx.Row{errFuncRow(errors.New("no rows")), errFuncRow(dbErr)}}
+	s := newMasteryStore(t, db)
+	if _, _, _, _, err := s.AwardQuestRewards(context.Background(), "u", 50, 5); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped upsert error, got %v", err)
+	}
+}
+
+// ── SaveTaunt ─────────────────────────────────────────────────────────────────
+
+func TestSaveTaunt_HappyPath(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{})
+	if err := s.SaveTaunt(context.Background(), "the_atom", 1, "taunt"); err != nil {
+		t.Fatalf("SaveTaunt: %v", err)
+	}
+}
+
+func TestSaveTaunt_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("exec failed")
+	s := newMasteryStore(t, &rowQueueDB{execErr: dbErr})
+	if err := s.SaveTaunt(context.Background(), "b", 1, "t"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── GetRandomTaunt ────────────────────────────────────────────────────────────
+
+func TestGetRandomTaunt_HappyPath(t *testing.T) {
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*string)) = "I will destroy you."
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	taunt, ok, err := s.GetRandomTaunt(context.Background(), "the_atom", 2)
+	if err != nil {
+		t.Fatalf("GetRandomTaunt: %v", err)
+	}
+	if !ok || taunt != "I will destroy you." {
+		t.Errorf("got ok=%v taunt=%q", ok, taunt)
+	}
+}
+
+func TestGetRandomTaunt_NoRows_ReturnsOkFalse(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(pgx.ErrNoRows)}})
+	_, ok, err := s.GetRandomTaunt(context.Background(), "b", 99)
+	if err != nil || ok {
+		t.Errorf("expected nil err and ok=false, got err=%v ok=%v", err, ok)
+	}
+}
+
+func TestGetRandomTaunt_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("db error")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, _, err := s.GetRandomTaunt(context.Background(), "b", 1); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── GetDefeatedBossIDs ────────────────────────────────────────────────────────
+
+func TestGetDefeatedBossIDs_HappyPath(t *testing.T) {
+	db := &queryDB{qrows: &stringRows{data: []string{"the_atom", "the_bonder"}}}
+	s := newMasteryStore(t, db)
+	ids, err := s.GetDefeatedBossIDs(context.Background(), "user-1")
+	if err != nil || len(ids) != 2 {
+		t.Errorf("GetDefeatedBossIDs: err=%v ids=%v", err, ids)
+	}
+}
+
+func TestGetDefeatedBossIDs_QueryError_Propagated(t *testing.T) {
+	dbErr := errors.New("query failed")
+	db := &queryDB{queryErr: dbErr}
+	s := newMasteryStore(t, db)
+	if _, err := s.GetDefeatedBossIDs(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── GetAchievements ───────────────────────────────────────────────────────────
+
+func TestGetAchievements_HappyPath(t *testing.T) {
+	now := time.Now()
+	db := &achievementQueryDB{rows: &achievementRows{data: [][]any{
+		{"ach-1", "user-1", "first_win", "First Victory", now},
+		{"ach-2", "user-1", "streak_7", "Week Warrior", now},
+	}}}
+	s := newMasteryStore(t, db)
+	got, err := s.GetAchievements(context.Background(), "user-1")
+	if err != nil || len(got) != 2 {
+		t.Errorf("GetAchievements: err=%v len=%d", err, len(got))
+	}
+}
+
+func TestGetAchievements_Empty_ReturnsEmptySlice(t *testing.T) {
+	db := &achievementQueryDB{rows: &achievementRows{data: nil}}
+	s := newMasteryStore(t, db)
+	got, err := s.GetAchievements(context.Background(), "fresh")
+	if err != nil {
+		t.Fatalf("GetAchievements: %v", err)
+	}
+	if got == nil {
+		t.Error("expected non-nil empty slice")
+	}
+}
+
+func TestGetAchievements_QueryError_Propagated(t *testing.T) {
+	dbErr := errors.New("query failed")
+	db := &achievementQueryDB{queryErr: dbErr}
+	s := newMasteryStore(t, db)
+	if _, err := s.GetAchievements(context.Background(), "u"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── GrantAchievement ──────────────────────────────────────────────────────────
+
+func TestGrantAchievement_NewAchievement_ReturnsTrue(t *testing.T) {
+	db := &grantAchievementDB{mainRow: achievementScanRow()}
+	s := newMasteryStore(t, db)
+	a, newly, err := s.GrantAchievement(context.Background(), "user-1", "first_win", "First Victory")
+	if err != nil || !newly || a == nil {
+		t.Errorf("GrantAchievement: err=%v newly=%v a=%v", err, newly, a)
+	}
+}
+
+func TestGrantAchievement_Duplicate_FetchesExisting(t *testing.T) {
+	db := &grantAchievementDB{
+		mainRow:  errFuncRow(errors.New("no rows in result set")),
+		fetchRow: achievementScanRow(),
+	}
+	s := newMasteryStore(t, db)
+	a, newly, err := s.GrantAchievement(context.Background(), "user-1", "first_win", "First Victory")
+	if err != nil || newly || a == nil {
+		t.Errorf("GrantAchievement duplicate: err=%v newly=%v a=%v", err, newly, a)
+	}
+}
+
+func TestGrantAchievement_DBError_Propagated(t *testing.T) {
+	db := &grantAchievementDB{mainRow: errFuncRow(errors.New("constraint"))}
+	s := newMasteryStore(t, db)
+	if _, _, err := s.GrantAchievement(context.Background(), "u", "x", "y"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ── AddCosmeticItem ───────────────────────────────────────────────────────────
+
+func TestAddCosmeticItem_HappyPath(t *testing.T) {
+	db := &execDB{}
+	s := newMasteryStore(t, db)
+	if err := s.AddCosmeticItem(context.Background(), "u", "frame", "gold"); err != nil {
+		t.Fatalf("AddCosmeticItem: %v", err)
+	}
+	if db.execCalls != 1 {
+		t.Errorf("expected 1 Exec call, got %d", db.execCalls)
+	}
+}
+
+func TestAddCosmeticItem_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("exec failed")
+	db := &execDB{execErr: dbErr}
+	s := newMasteryStore(t, db)
+	if err := s.AddCosmeticItem(context.Background(), "u", "k", "v"); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}
+
+// ── BuyPowerUp ────────────────────────────────────────────────────────────────
+
+func TestBuyPowerUp_HappyPath(t *testing.T) {
+	inv, _ := json.Marshal(map[string]int{"shield": 2})
+	db := &rowQueueDB{rows: []pgx.Row{&funcRow{fn: func(dest ...any) error {
+		*(dest[0].(*int)) = 80
+		*(dest[1].(*[]byte)) = inv
+		return nil
+	}}}}
+	s := newMasteryStore(t, db)
+	gemsLeft, count, err := s.BuyPowerUp(context.Background(), "u", "shield", 20)
+	if err != nil || gemsLeft != 80 || count != 2 {
+		t.Errorf("BuyPowerUp: err=%v gems=%d count=%d", err, gemsLeft, count)
+	}
+}
+
+func TestBuyPowerUp_ErrNoRows_ReturnsErrNoGems(t *testing.T) {
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(pgx.ErrNoRows)}})
+	if _, _, err := s.BuyPowerUp(context.Background(), "u", "shield", 9999); err == nil {
+		t.Fatal("expected ErrNoGems, got nil")
+	}
+}
+
+func TestBuyPowerUp_DBError_Propagated(t *testing.T) {
+	dbErr := errors.New("db error")
+	s := newMasteryStore(t, &rowQueueDB{rows: []pgx.Row{errFuncRow(dbErr)}})
+	if _, _, err := s.BuyPowerUp(context.Background(), "u", "shield", 10); !errors.Is(err, dbErr) {
+		t.Errorf("expected wrapped error, got %v", err)
+	}
+}


### PR DESCRIPTION
## What
Add integration tests for gaming-service store package, bringing coverage from 27.2% to 90.1%.

Also fixes `intRow` duplicate declaration: `streak_freeze_test.go` (already on main) and `battle_coverage_test.go` both declared `type intRow struct` in `package store_test`, causing a compile-time error in the merge queue. Renamed to `battleIntRow` throughout.

## Why
Bead ID: tl-3r5 — store layer test coverage requirement.

## How to test
```
cd services/gaming-service && go test ./internal/store/... -count=1
```

## Checklist
- [x] Tests written (TDD) — 8 test files added
- [x] Coverage ≥80% on new code (27.2% → 90.1%)
- [x] Lint clean
- [x] No secrets committed
- [x] intRow duplicate resolved