### PR TITLE
feat(hq-4lun): victory particles burst on LootReveal

### DIFF
--- a/frontend/components/boss/LootReveal.tsx
+++ b/frontend/components/boss/LootReveal.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import VictoryParticles from './VictoryParticles'
 
 /** A single loot line item. */
 export interface LootItem {
@@ -61,37 +62,40 @@ export default function LootReveal({
   }, [revealed, items.length, staggerMs, onContinue])
 
   return (
-    <div
-      role="region"
-      aria-label="Battle rewards"
-      className="flex flex-col gap-2 w-full max-w-sm mx-auto px-4 py-6 rounded-lg border border-neon-gold/40 bg-bg-panel/60"
-    >
-      <h2 className="text-sm font-mono font-bold text-neon-gold tracking-wider text-center mb-2">
-        LOOT REVEALED
-      </h2>
-      {items.map((item, idx) => {
-        const visible = idx < revealed
-        return (
-          <div
-            key={item.key}
-            data-testid={`loot-row-${item.key}`}
-            aria-hidden={!visible}
-            className={`flex items-center gap-3 px-3 py-2 rounded-md border transition-all duration-300 ${
-              visible
-                ? 'opacity-100 translate-y-0 border-neon-gold/30 bg-neon-gold/5'
-                : 'opacity-0 translate-y-2 border-transparent'
-            }`}
-          >
-            <span aria-hidden="true" className="text-lg">
-              {item.icon}
-            </span>
-            <span className="text-xs font-mono text-text-bright flex-1">{item.label}</span>
-            {item.amount !== null && (
-              <span className="text-xs font-mono font-bold text-neon-gold">+{item.amount}</span>
-            )}
-          </div>
-        )
-      })}
-    </div>
+    <>
+      <VictoryParticles active={items.length > 0} />
+      <div
+        role="region"
+        aria-label="Battle rewards"
+        className="flex flex-col gap-2 w-full max-w-sm mx-auto px-4 py-6 rounded-lg border border-neon-gold/40 bg-bg-panel/60"
+      >
+        <h2 className="text-sm font-mono font-bold text-neon-gold tracking-wider text-center mb-2">
+          LOOT REVEALED
+        </h2>
+        {items.map((item, idx) => {
+          const visible = idx < revealed
+          return (
+            <div
+              key={item.key}
+              data-testid={`loot-row-${item.key}`}
+              aria-hidden={!visible}
+              className={`flex items-center gap-3 px-3 py-2 rounded-md border transition-all duration-300 ${
+                visible
+                  ? 'opacity-100 translate-y-0 border-neon-gold/30 bg-neon-gold/5'
+                  : 'opacity-0 translate-y-2 border-transparent'
+              }`}
+            >
+              <span aria-hidden="true" className="text-lg">
+                {item.icon}
+              </span>
+              <span className="text-xs font-mono text-text-bright flex-1">{item.label}</span>
+              {item.amount !== null && (
+                <span className="text-xs font-mono font-bold text-neon-gold">+{item.amount}</span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </>
   )
 }

--- a/frontend/components/boss/VictoryParticles.tsx
+++ b/frontend/components/boss/VictoryParticles.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+/**
+ * VictoryParticles.tsx (hq-4lun)
+ *
+ * Lightweight canvas-based confetti burst rendered on top of LootReveal when
+ * the player clears a boss. Self-contained — no third-party particle library.
+ *
+ * Honours `prefers-reduced-motion`: if the user has reduced-motion enabled,
+ * the component renders nothing at all (no canvas, no animation loop).
+ */
+
+import { useEffect, useRef } from 'react'
+
+/** Single confetti shred. Mutated in place each frame. */
+interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  size: number
+  rotation: number
+  rotationSpeed: number
+  colour: string
+}
+
+/** Neon palette matched to the LootReveal panel border / content colours. */
+const COLOURS = [
+  '#ffd700', // neon-gold
+  '#22d3ee', // neon-blue
+  '#f472b6', // neon-pink
+  '#4ade80', // neon-green
+  '#a78bfa', // neon-purple
+]
+
+/** Total run-time for the burst in milliseconds. */
+const DURATION_MS = 2200
+
+/** Number of confetti pieces per burst. */
+const PARTICLE_COUNT = 80
+
+/** Gravity in px/s² applied to each particle's vy each frame. */
+const GRAVITY = 900
+
+export interface VictoryParticlesProps {
+  /**
+   * When true, the burst is mounted and animation begins. Toggling false
+   * (or unmounting the component) stops the loop and clears the canvas.
+   */
+  active: boolean
+}
+
+/**
+ * Returns true if the user has requested reduced motion. SSR-safe.
+ */
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/**
+ * VictoryParticles renders a one-shot confetti burst on a fixed full-screen
+ * canvas. The canvas is purely decorative (`aria-hidden`) and does not block
+ * pointer events.
+ */
+export default function VictoryParticles({ active }: VictoryParticlesProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const reduced = prefersReducedMotion()
+
+  useEffect(() => {
+    if (!active || reduced) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+    const width = window.innerWidth
+    const height = window.innerHeight
+    canvas.width = Math.floor(width * dpr)
+    canvas.height = Math.floor(height * dpr)
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+    ctx.scale(dpr, dpr)
+
+    const originX = width / 2
+    const originY = height / 2
+    const particles: Particle[] = Array.from({ length: PARTICLE_COUNT }, () => {
+      const angle = Math.random() * Math.PI * 2
+      const speed = 250 + Math.random() * 350
+      return {
+        x: originX,
+        y: originY,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 200,
+        size: 4 + Math.random() * 4,
+        rotation: Math.random() * Math.PI * 2,
+        rotationSpeed: (Math.random() - 0.5) * 8,
+        colour: COLOURS[Math.floor(Math.random() * COLOURS.length)],
+      }
+    })
+
+    let rafId = 0
+    let lastT = performance.now()
+    const start = lastT
+
+    const tick = (now: number) => {
+      const dt = Math.min(0.05, (now - lastT) / 1000)
+      lastT = now
+      const elapsed = now - start
+      const lifeFrac = Math.min(1, elapsed / DURATION_MS)
+      const alpha = 1 - lifeFrac
+
+      ctx.clearRect(0, 0, width, height)
+
+      for (const p of particles) {
+        p.vy += GRAVITY * dt
+        p.x += p.vx * dt
+        p.y += p.vy * dt
+        p.rotation += p.rotationSpeed * dt
+
+        ctx.save()
+        ctx.globalAlpha = alpha
+        ctx.translate(p.x, p.y)
+        ctx.rotate(p.rotation)
+        ctx.fillStyle = p.colour
+        ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.5)
+        ctx.restore()
+      }
+
+      if (elapsed < DURATION_MS) {
+        rafId = requestAnimationFrame(tick)
+      } else {
+        ctx.clearRect(0, 0, width, height)
+      }
+    }
+
+    rafId = requestAnimationFrame(tick)
+    return () => {
+      cancelAnimationFrame(rafId)
+      ctx.clearRect(0, 0, width, height)
+    }
+  }, [active, reduced])
+
+  if (!active || reduced) return null
+
+  return (
+    <canvas
+      ref={canvasRef}
+      data-testid="victory-particles"
+      aria-hidden="true"
+      className="fixed inset-0 pointer-events-none z-40"
+    />
+  )
+}

--- a/frontend/components/boss/victoryParticles.test.tsx
+++ b/frontend/components/boss/victoryParticles.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import 'jest-canvas-mock'
+import VictoryParticles from './VictoryParticles'
+
+/**
+ * Stub matchMedia so we can flip between reduced-motion on/off per test.
+ */
+function setReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes('reduce') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}
+
+describe('VictoryParticles', () => {
+  let rafSpy: jest.SpyInstance
+  let cancelSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    setReducedMotion(false)
+    let callCount = 0
+    rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      callCount += 1
+      // Drive exactly one frame to exercise the paint path; ignore subsequent
+      // schedule calls so the loop terminates instead of recursing forever.
+      if (callCount === 1) cb(performance.now() + 16)
+      return callCount as unknown as number
+    })
+    cancelSpy = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    rafSpy.mockRestore()
+    cancelSpy.mockRestore()
+  })
+
+  it('renders a decorative canvas when active', () => {
+    render(<VictoryParticles active={true} />)
+    const canvas = screen.getByTestId('victory-particles')
+    expect(canvas.tagName).toBe('CANVAS')
+    expect(canvas).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('renders nothing when inactive', () => {
+    render(<VictoryParticles active={false} />)
+    expect(screen.queryByTestId('victory-particles')).toBeNull()
+  })
+
+  it('renders nothing when prefers-reduced-motion is set', () => {
+    setReducedMotion(true)
+    render(<VictoryParticles active={true} />)
+    expect(screen.queryByTestId('victory-particles')).toBeNull()
+  })
+
+  it('schedules an animation frame on mount and cancels on unmount', () => {
+    const { unmount } = render(<VictoryParticles active={true} />)
+    expect(rafSpy).toHaveBeenCalled()
+    unmount()
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What
Adds a self-contained canvas confetti burst (`VictoryParticles`) rendered on top of `LootReveal` when the player clears a boss. ~80 gravity-affected shreds in the neon palette, 2.2 s burst with alpha fade-out. No third-party particle library.

## Why
Bead **hq-4lun** (#2 of three deferred polish items from tl-dye/tl-nu8). Spec called for "tsparticles / canvas confetti burst on LootReveal when the user clears a boss. Respect prefers-reduced-motion."

## Detail

### Current Behavior
`LootReveal` (wired into `BossBattleClient` victory phase by tl-dye / PR #245) staggers in each loot row but provides no celebratory effect on victory. Quiet visual payoff for clearing a boss.

### New Behavior
`LootReveal` now renders `<VictoryParticles active={items.length > 0} />` alongside the rewards panel. A fixed full-screen `<canvas>` (`pointer-events: none`, `aria-hidden`, `z-40`) draws an outward burst of confetti shreds with gravity, rotation, and alpha decay over ~2.2 s, then clears itself.

When `prefers-reduced-motion: reduce` is set, the component returns `null` — no canvas mounted, no animation loop scheduled.

### Implementation Notes
- Pure canvas + `requestAnimationFrame`. DPR-aware sizing.
- 80 particles, palette matches existing `neon-*` tokens (gold/blue/pink/green/purple).
- Loop self-terminates after `DURATION_MS` (2200 ms); also cancelled on unmount.
- SSR-safe `prefersReducedMotion()` guards `window.matchMedia` access.

## How to test
1. `cd frontend && npm test -- victoryParticles` — VictoryParticles unit tests
2. `cd frontend && npm test -- lootReveal` — confirms LootReveal tests still green
3. Manual: clear a boss in `BossBattleClient`; confirm a burst plays once over the loot panel and pointer events still pass through.
4. Manual reduced-motion: toggle OS reduce-motion → reload → clear boss → no canvas, no burst.

## Checklist
- [x] Tests written (TDD) — `frontend/components/boss/victoryParticles.test.tsx` (4 cases: active render, inactive null, reduced-motion null, rAF schedule+cancel)
- [x] Coverage ≥90% on new code — VictoryParticles 96.97% stmt / 100% func
- [x] Docstrings on all new functions/components (TSDoc on component, helpers, props)
- [x] Lint clean (`npm run lint` ✔)
- [x] Prettier clean (`npm run format:check` ✔ on touched files)
- [x] All 869 frontend tests pass
- [x] No secrets committed
- [x] Self-review: read own diff before opening

Closes hq-4lun (#2 of 3 — particles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)